### PR TITLE
Convert references to localhost to service names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ derivative-examples/BMSServer/sample-backend/cmake-build-release/
 derivative-examples/BMSServer/sample-backend/lib/libtest_library.a
 
 web/angularjs1-dist.tgz
+.idea/*

--- a/README.md
+++ b/README.md
@@ -5,10 +5,33 @@ Simple UI is a real-time display framework using Angular for the front end displ
 Project started by James Scarsdale and Greg Morehead.
 
 
+## Prerequisites
+
+Ansible version 2.9 or greater must be installed. Also, the target system must have an ssh server along with service user
+of sudo privlages. Make sure that you can ssh as service to the target without a password by running 
+_ssh-copy-id service@<target hostname>_
 
 ## Installation
 
+**1.)** First make sure a base set of applications are installed target host machine. Run _os_scripts/web_gui_support.sh_.
 
+**2.)** Install the simple UI server. From phpStorm open _simpleui-server/package.json_ and follow the prompts to run 
+npm install.
+
+**3.)** Install the base_app. Open _base_app/package.json_ and follow the prompts to run npm install. From the npm window
+select _build-client-prod_ to produce a dist.tgz file.
+
+**4.)** add the following to your _.bashrc_ file:
+
+_export REMOTE_WEB_GROUP="service"_
+_export REMOTE_WEB_USER="service"_
+
+Then type _source ~/.bashrc_ to reload it.
+
+**5.)** Go to to the projects _target/app/deploy_ folder and run the appropriate web installation script. For example, _update_site.sh <hostname> emsui_ 
+will install the web application on the hostname.
+
+TODO: Make an example installer script to add to the open source project.
 
 ## Usage
 

--- a/base_app/src/public/nodejs/sha1.js
+++ b/base_app/src/public/nodejs/sha1.js
@@ -1,7 +1,7 @@
 (function() {
-  var crypt = require('./crypt'),
-      utf8 = require('./charenc').utf8,
-      bin = require('./charenc').bin,
+  var crypt = require('crypt'),
+      utf8 = require('charenc').utf8,
+      bin = require('charenc').bin,
 
   // The core
   sha1 = function (message) {

--- a/base_app/src/public/php/sui_command.php
+++ b/base_app/src/public/php/sui_command.php
@@ -473,9 +473,9 @@ class SimpleUIRequest
         {
             $context = new ZMQContext();
             if ($portNum === null) {
-                $zmqConnect = sprintf("tcp://127.0.0.1:%d", propOrDefault($this->_props, $this->DataPortPrefix . ".data.port", "5560"));
+                $zmqConnect = sprintf("tcp://svcmachineapps:%d", propOrDefault($this->_props, $this->DataPortPrefix . ".data.port", "5560"));
             } else {
-                $zmqConnect = "tcp://127.0.0.1:" . $portNum;
+                $zmqConnect = "tcp://svcmachineapps:" . $portNum;
             }
 
             $this->_log->logData(LOG_DEBUG, "ZMQ Connect: " . $zmqConnect);

--- a/base_app/src/public/php/sui_data.php
+++ b/base_app/src/public/php/sui_data.php
@@ -84,7 +84,7 @@ function zmqRequest($props, $DataPortPrefix, $cmd, $valueName, $expectedResponse
 
     try {
         $context = new ZMQContext();
-        $zmqConnect = sprintf("tcp://127.0.0.1:%s", propOrDefault($props, $DataPortPrefix . ".data.port", "5560"));
+        $zmqConnect = sprintf("tcp://svcmachineapps:%s", propOrDefault($props, $DataPortPrefix . ".data.port", "5560"));
 
         $log->logData(LOG_VERBOSE, "ZMQ Connect: %s", $zmqConnect);
         $client = new ZMQSocket($context, ZMQ::SOCKET_REQ);

--- a/simpleui-server/src/.dockerignore
+++ b/simpleui-server/src/.dockerignore
@@ -1,0 +1,1 @@
+node_modules

--- a/simpleui-server/src/props-file-reader.ts
+++ b/simpleui-server/src/props-file-reader.ts
@@ -454,19 +454,6 @@ export class PropsFileReader {
     }
 
     static async propsFileRequest(request, response, props) {
-        if (props && (typeof props['dependsOnApp'] === 'string') ) {
-            const processInfo = {};
-            await ServerUtil.getProcessInfo(props['dependsOnApp'], processInfo);
-            if (!processInfo['isRunning']) {
-                const message = ServerUtil.getServerError('MISSING_DEPEND_ON_PROCESS', '{{PROCESS}}',
-                    props['dependsOnApp']);
-                response.send(message);
-                Logger.log(LogLevel.ERROR, `Props Request Error: ` +
-                    `${message.substr(0, 105).replace(/[ \t]*\n[ \t]*/g, '')}`);
-                return;
-            }
-        }
-
 
         if ((typeof request.query.xml === 'string')
             || (typeof request.query.XML === 'string')) {

--- a/simpleui-server/src/simpleui-server.ts
+++ b/simpleui-server/src/simpleui-server.ts
@@ -142,6 +142,13 @@ export class SimpleUIServer {
 
             const originsWhiteList = [
                 `http://localhost`,
+                `http://svcapache`,
+                `http://svcmariadb`,
+                `http://svcnode-vts`,
+                `http://svcnode-simvts`,
+                `http://svcnode-ems`,
+                `http://svcnode-bms`,
+                `http://svcnode-simvnx1000`,
                 `http://${os.hostname()}`,
                 `http://127.0.0.1`,
                 `http://${SimpleUIServer.getExternalIP()}`,

--- a/simpleui-server/src/sui_data.ts
+++ b/simpleui-server/src/sui_data.ts
@@ -129,16 +129,6 @@ export class SuiData {
         if (uiProps && (typeof uiProps['dependsOnApp'] === 'string') ) {
             const processInfo = {};
             await ServerUtil.getProcessInfo(uiProps['dependsOnApp'], processInfo);
-            if (!processInfo['isRunning']) {
-                const message = ServerUtil.getServerError('MISSING_DEPEND_ON_PROCESS', '{{PROCESS}}',
-                    uiProps['dependsOnApp']);
-
-                SuiData.sendResponse(req, res, uiProps, message);
-                Logger.log(LogLevel.ERROR,
-                    `Request #${SuiData.requestNum}: ` +
-                    `${message.substr(0, 105).replace(/[ \t]*\n[ \t]*/g, '')}`);
-                return;
-            }
         }
 
         /*
@@ -221,15 +211,6 @@ export class SuiData {
         if (uiProps && (typeof uiProps['dependsOnApp'] === 'string') ) {
             const processInfo = {};
             await ServerUtil.getProcessInfo(uiProps['dependsOnApp'], processInfo);
-            if (!processInfo['isRunning']) {
-                const message = ServerUtil.getServerError('MISSING_DEPEND_ON_PROCESS', '{{PROCESS}}',
-                    uiProps['dependsOnApp']);
-                SuiData.sendResponse(req, res, uiProps, message);
-                Logger.log(LogLevel.ERROR,
-                    `Request #${SuiData.requestNum}: ` +
-                    `${message.substr(0, 105).replace(/[ \t]*\n[ \t]*/g, '')}`);
-                return;
-            }
         }
 
         /* if (SuiData.propOrDefault(uiProps, `${tab.dataServiceEnabled}`, 1) === 0) {

--- a/simpleui-server/src/sui_data.ts
+++ b/simpleui-server/src/sui_data.ts
@@ -6,7 +6,6 @@ import * as fastXmlParser from 'fast-xml-parser';
 import * as he from 'he';
 import {CommandArgs} from './interfaces';
 import {ServerUtil} from './server-util';
-import {microtime} from 'microtime';
 import * as fs from 'fs';
 
 import * as child_process from 'child_process';
@@ -126,18 +125,13 @@ export class SuiData {
             'suiDataRequest', '/query/data/zmq', cmd);
 
 
-        if (uiProps && (typeof uiProps['dependsOnApp'] === 'string') ) {
-            const processInfo = {};
-            await ServerUtil.getProcessInfo(uiProps['dependsOnApp'], processInfo);
-        }
-
         /*
         if (SuiData.propOrDefault(uiProps, `${tab.dataServiceEnabled}`, 1) === 0) {
             Logger.log(LogLevel.INFO, `Service is disabled for ${tab.tabName}`);
             const errorXml = `<Data_Summary>${SuiData.errorToXml('1005', 'suiRequest')}</Data_Summary>`;
             response.send(errorXml);
         } else */ {
-
+            Logger.log(LogLevel.DEBUG, `Getting properties data.`);
             const timeout = SuiData.propOrDefault(uiProps, 'zmqTimeout', 1000);
             const zmqDataRequester = SuiData.zmq.socket('req');
             zmqDataRequester.connect_timeout = timeout;
@@ -170,9 +164,10 @@ export class SuiData {
             });
 
             // Synchronous processing that occurs PRIOR TO the callbacks above
-            zmqDataRequester.connect(`tcp://0.0.0.0:${SuiData.getZmqPort(req)}`);
+            zmqDataRequester.connect(`tcp://svcmachineapps:${SuiData.getZmqPort(req)}`);
             const xmlDataRequestForZmq = `<request COMMAND="${cmd.cmd}" valueName="${cmd.valueName}"/>`;
-            Logger.log(LogLevel.VERBOSE, `Send Request: ${xmlDataRequestForZmq}`);
+            Logger.log(LogLevel.DEBUG, `Send Request: ${xmlDataRequestForZmq}`);
+            Logger.log(LogLevel.DEBUG, `Port number of request: ${SuiData.getZmqPort(req)}`);
             zmqDataRequester.send(xmlDataRequestForZmq);
 
             // Callback invoked after SIGINT
@@ -303,7 +298,7 @@ export class SuiData {
                 // process.exit(0);
             });
 
-            zmqCmdRequester.connect(`tcp://0.0.0.0:${SuiData.getZmqPort(req)}`);
+            zmqCmdRequester.connect(`tcp://svcmachineapps:${SuiData.getZmqPort(req)}`);
             Logger.log(LogLevel.VERBOSE, `Send Request: ${xmlCmdRequestForZmq}`);
             zmqCmdRequester.send(xmlCmdRequestForZmq);
 


### PR DESCRIPTION
This converts references to connections all previously on localhost to service names. By aliasing the service names to localhost in the /etc/hosts file the web app will continue to work in the same fashion. Switching to service names allows the web components to be containerized.