### PR TITLE
remove mat-form-field tag from noControls conditional

### DIFF
--- a/base_app/src/app/cmdsets/material-popup-component.html
+++ b/base_app/src/app/cmdsets/material-popup-component.html
@@ -17,8 +17,8 @@
                        [formControl]="inputControl"
                        [value]="control.value"
                        [matDatepicker]="myDatepicker"
-                       [title]="control.desc"
-                />
+                       [title]="control.desc">
+
                 <mat-datepicker-toggle matSuffix [for]='myDatepicker'>
                 </mat-datepicker-toggle>
                 <mat-datepicker #myDatepicker></mat-datepicker>
@@ -37,9 +37,8 @@
                        [checked]="control.checked"
                        [name]="control.name"
                        [placeholder]="control.name"
-                       [title]="control.desc">{{control.label}}
-
-
+                       [title]="control.desc">
+                {{control.label}}
             </mat-form-field>
 
             <mat-form-field appearance="fill" *ngIf='control.type === "int"'>
@@ -48,8 +47,7 @@
                        [formControl]="inputControl"
                        [value]="control.value"
                        [placeholder]="control.name"
-                       [title]="control.desc"
-                />
+                       [title]="control.desc">
             </mat-form-field>
 
             <mat-form-field appearance="fill"  *ngIf='control.type === "float"'>
@@ -58,8 +56,7 @@
                        [formControl]="inputControl"
                        [value]="control.value"
                        [placeholder]="control.name"
-                       [title]="control.desc"
-                />
+                       [title]="control.desc">
             </mat-form-field>
 
             <mat-form-field appearance="fill" *ngIf='control.type === "text"'>
@@ -68,7 +65,7 @@
                        [formControl]="inputControl"
                        [value]="control.value"
                        [placeholder]="control.name"
-                       [title]="control.desc"/>
+                       [title]="control.desc">
             </mat-form-field>
 
             <mat-form-field appearance="fill" *ngIf='control.type === "textarea"'>
@@ -86,8 +83,7 @@
                        [formControl]="inputControl"
                        [value]="control.value"
                        [placeholder]="control.name"
-                       [title]="control.desc"
-                />
+                       [title]="control.desc">
             </mat-form-field>
         </div>
     </form>

--- a/base_app/src/app/cmdsets/material-popup-component.html
+++ b/base_app/src/app/cmdsets/material-popup-component.html
@@ -6,9 +6,7 @@
         </div>
 
         <div *ngIf='noControls === true'>
-            <mat-form-field>
-                Execute command <i>{{cmd}}</i> ?
-            </mat-form-field>
+            <p>Execute command <i>{{cmd}}</i> ?</p>
         </div>
 
         <div *ngFor='let control of commandData.element["command"].controls'>
@@ -34,13 +32,13 @@
 
             <mat-form-field appearance="fill" *ngIf='control.type === "bool"'>
                 <input matInput type='checkbox' [id]="'popup-control-' + control.id"
-                       [formControl]="inputControl" 
+                       [formControl]="inputControl"
                        [attr.aria-label]="'labelFor-' + control.id"
-                       [checked]="control.checked"  
+                       [checked]="control.checked"
                        [name]="control.name"
                        [placeholder]="control.name"
                        [title]="control.desc">{{control.label}}
-                />
+
 
             </mat-form-field>
 
@@ -99,3 +97,4 @@
     <button class='mat-raised-button mat-primary' (click)='onOK()'>OK</button>
     <button class='mat-raised-button' (click)='onCancel()'>Cancel</button>
 </div>
+

--- a/base_app/src/app/cmdsets/material-popup-component.html
+++ b/base_app/src/app/cmdsets/material-popup-component.html
@@ -17,7 +17,8 @@
                        [formControl]="inputControl"
                        [value]="control.value"
                        [matDatepicker]="myDatepicker"
-                       [title]="control.desc">
+                       [title]="control.desc"
+                />
 
                 <mat-datepicker-toggle matSuffix [for]='myDatepicker'>
                 </mat-datepicker-toggle>
@@ -37,7 +38,8 @@
                        [checked]="control.checked"
                        [name]="control.name"
                        [placeholder]="control.name"
-                       [title]="control.desc">
+                       [title]="control.desc"
+                />
                 {{control.label}}
             </mat-form-field>
 
@@ -47,7 +49,8 @@
                        [formControl]="inputControl"
                        [value]="control.value"
                        [placeholder]="control.name"
-                       [title]="control.desc">
+                       [title]="control.desc"
+                />
             </mat-form-field>
 
             <mat-form-field appearance="fill"  *ngIf='control.type === "float"'>
@@ -56,7 +59,8 @@
                        [formControl]="inputControl"
                        [value]="control.value"
                        [placeholder]="control.name"
-                       [title]="control.desc">
+                       [title]="control.desc"
+                />
             </mat-form-field>
 
             <mat-form-field appearance="fill" *ngIf='control.type === "text"'>
@@ -65,7 +69,8 @@
                        [formControl]="inputControl"
                        [value]="control.value"
                        [placeholder]="control.name"
-                       [title]="control.desc">
+                       [title]="control.desc"
+                />
             </mat-form-field>
 
             <mat-form-field appearance="fill" *ngIf='control.type === "textarea"'>
@@ -83,7 +88,8 @@
                        [formControl]="inputControl"
                        [value]="control.value"
                        [placeholder]="control.name"
-                       [title]="control.desc">
+                       [title]="control.desc"
+                />
             </mat-form-field>
         </div>
     </form>


### PR DESCRIPTION
When a button with a popup had no controls (AKA no inputs), it would throw `ERROR: mat-form-field must contain a MatFormFieldControl` when clicked. This is because the conditional that handles these type of buttons in `material-popup-component.html` was wrapped with the `<mat-form-field>`. This tag requires a input of some sort (drop down, textarea, etc.) which the option does not need. Removing the `<mat-form-field>` tag from this conditional fixed the issue.