### PR TITLE
Make cli override option

### DIFF
--- a/deploy_docker/run.sh
+++ b/deploy_docker/run.sh
@@ -1,14 +1,21 @@
 #!/bin/bash
 
-# Print command line help
-if test "$#" \< "1"; then
-  printf "\n    run.sh - runs simpleui for docker\n"
-  printf "\n    Usage: run.sh YOUR_APP_NAME\n"
-  printf "      where 'YOUR_APP_NAME' is the name of the application.\n"
-  exit 1
+
+
+all_args="$@";
+
+if test "$#" \< "2"; then
+    echo "run.sh - runs simpleui for docker";
+    echo "Usage: run.sh YOUR_APP_NAME --zmqHostname=YOUR_ZMQ_HOSTNAME";
+    echo "Other options include:";
+    printf "\t zmqHostname ==> zmq's hostname (required)\n";
+    printf "\t dbName      ==> override DB name (optional)\n";
+    printf "\t themeName   ==> override themeName (optional)\n";
+    exit 1;
 fi
-# Parse command line
-app_name="$1"
+
+# parse app name
+app_name="$1";
 
 # Run the merging script
 source /scripts/merge_app.sh "$app_name"
@@ -18,4 +25,4 @@ source /scripts/merge_app.sh "$app_name"
 docker-php-entrypoint apache2-foreground &
 
 # Run node
-node /var/www/"$app_name"/simpleui-server/simpleui-server.js --mode=daemon --appName="$app_name" --webPort=2080 --zmqHostname=svcmachineapps
+node /var/www/"$app_name"/simpleui-server/simpleui-server.js --mode=daemon --webPort=2080 --appName="$app_name" "$all_args"

--- a/deploy_docker/run.sh
+++ b/deploy_docker/run.sh
@@ -8,7 +8,7 @@ if test "$#" \< "2"; then
     echo "run.sh - runs simpleui for docker";
     echo "Usage: run.sh YOUR_APP_NAME --zmqHostname=YOUR_ZMQ_HOSTNAME";
     echo "Other options include:";
-    printf "\t zmqHostname ==> zmq's hostname (required)\n";
+    printf "\t zmqHostname ==> address/hostname of native app zmq sockets (required)\n";
     printf "\t dbName      ==> override DB name (optional)\n";
     printf "\t themeName   ==> override themeName (optional)\n";
     exit 1;

--- a/deploy_docker/run.sh
+++ b/deploy_docker/run.sh
@@ -18,4 +18,4 @@ source /scripts/merge_app.sh "$app_name"
 docker-php-entrypoint apache2-foreground &
 
 # Run node
-node /var/www/"$app_name"/simpleui-server/simpleui-server.js --mode=daemon --appName="$app_name" --webPort=2080
+node /var/www/"$app_name"/simpleui-server/simpleui-server.js --mode=daemon --appName="$app_name" --webPort=2080 --zmqHostname=svcmachineapps

--- a/develop_docker/install-script-debug-simpleui-server.bash
+++ b/develop_docker/install-script-debug-simpleui-server.bash
@@ -6,13 +6,13 @@
     if [[ ! -d .vscode ]]; then
         mkdir .vscode;
         cd .vscode && touch launch.json;
-        echo '{"configurations": [{"name": "Debug server","type": "node","request": "launch","program": "${workspaceFolder}/simpleui-server/dist/simpleui-server/simpleui-server.js","args": ["--mode=daemon","--appName=sample-app","--webPort=4100"]}]}' > launch.json
+        echo '{"configurations": [{"name": "Debug server","type": "node","request": "launch","program": "${workspaceFolder}/simpleui-server/dist/simpleui-server/simpleui-server.js","args": ["--mode=daemon","--appName=simple_ui","--webPort=4100","--zmqHostname=svcmachineapps"]}]}' > launch.json
     fi
  )
 
 # ----------- simpleui-server -----------
 cd /usr/src/app/simpleui-server || exit 1
-if [[ ! -d node_modules ]]; then 
+if [[ ! -d node_modules ]]; then
     npm install -f;
 fi
 npm run build;

--- a/develop_docker/install-script.bash
+++ b/develop_docker/install-script.bash
@@ -23,7 +23,8 @@ npm run build;
 /tini -- node /usr/src/app/simpleui-server/dist/simpleui-server/simpleui-server.js \
 --mode=daemon \
 --appName=simple_ui \
---webPort=4100 &
+--webPort=4100 \
+--zmqHostname=svcmachineapps &
 
 
 # -------------- base_app --------------

--- a/simpleui-server/src/interfaces.ts
+++ b/simpleui-server/src/interfaces.ts
@@ -1,7 +1,6 @@
 
 export interface CommandArgs {
     valid: boolean;
-    override: boolean;
     help: string;
     errors: string;
     mode: string;

--- a/simpleui-server/src/interfaces.ts
+++ b/simpleui-server/src/interfaces.ts
@@ -1,6 +1,7 @@
 
 export interface CommandArgs {
     valid: boolean;
+    override: boolean;
     help: string;
     errors: string;
     mode: string;
@@ -8,6 +9,9 @@ export interface CommandArgs {
     webPort: string;
     xmlInFile: string;
     jsonOutFile: string;
+    zmqHostname: string;
+    DBname: string;
+    theme: string;
 }
 
 export interface ProcessInfo {

--- a/simpleui-server/src/interfaces.ts
+++ b/simpleui-server/src/interfaces.ts
@@ -10,8 +10,8 @@ export interface CommandArgs {
     xmlInFile: string;
     jsonOutFile: string;
     zmqHostname: string;
-    DBname: string;
-    theme: string;
+    DbName: string;
+    themeName: string;
 }
 
 export interface ProcessInfo {

--- a/simpleui-server/src/interfaces.ts
+++ b/simpleui-server/src/interfaces.ts
@@ -11,6 +11,7 @@ export interface CommandArgs {
     zmqHostname: string;
     dbName: string;
     themeName: string;
+    mock: boolean;
 }
 
 export interface ProcessInfo {

--- a/simpleui-server/src/interfaces.ts
+++ b/simpleui-server/src/interfaces.ts
@@ -9,7 +9,7 @@ export interface CommandArgs {
     xmlInFile: string;
     jsonOutFile: string;
     zmqHostname: string;
-    DbName: string;
+    dbName: string;
     themeName: string;
 }
 

--- a/simpleui-server/src/props-file-reader.ts
+++ b/simpleui-server/src/props-file-reader.ts
@@ -254,8 +254,8 @@ export class PropsFileReader {
                 props['macro'][macroIndex]['property'] = property;
 
                 // override dbname with given value
-                if (PropsFileReader.cmdVars.DbName !== "" && token.includes("_MYSQL_DB")) {
-                    Logger.log(LogLevel.INFO, `Overriding macro ${token} with ${PropsFileReader.cmdVars.DbName}`);
+                if (PropsFileReader.cmdVars.DbName !== "" && token.endsWith("_MYSQL_DB")) {
+                    Logger.log(LogLevel.INFO, `Overriding macro ${token} with the value of cmd line arg "--DbName ${PropsFileReader.cmdVars.DbName}"`);
                     props['macro'][macroIndex]['replacement'] = PropsFileReader.cmdVars.DbName
                 } else {
                     PropsFileReader.processMacroPart(props, macroIndex);

--- a/simpleui-server/src/props-file-reader.ts
+++ b/simpleui-server/src/props-file-reader.ts
@@ -43,6 +43,7 @@ export class PropsFileReader {
         zmqHostname: '',
         dbName: '',
         themeName: '',
+        mock: false
     };
 
     static getAppPropsFiles(): any {
@@ -54,8 +55,7 @@ export class PropsFileReader {
         for (let appName of appNames) {
             appName = appName.trim();
 
-            let isMock = (appName.substring(0, 5) === "mock-");
-
+            let isMock = PropsFileReader.cmdVars.mock;
 
             let propsDir = `/var/www/${appName}`;
             if (isMock) { propsDir = `${SimpleUIServer.bin_dir}/../../test/data/${appName.replace("mock-", "")}`; }

--- a/simpleui-server/src/props-file-reader.ts
+++ b/simpleui-server/src/props-file-reader.ts
@@ -21,7 +21,6 @@ export class PropsFileReader {
     static cmdVars: CommandArgs = <CommandArgs> {
         valid: true,
         help: '\nSyntax:\n\n', // Each arg help is appended in arg definition
-        override: false,
         examples: '\n\nExample for running as a daemon:' +
             '\n  node simpleui-server.js \\' +
             '\n     --appName=bms \\' +

--- a/simpleui-server/src/props-file-reader.ts
+++ b/simpleui-server/src/props-file-reader.ts
@@ -254,7 +254,7 @@ export class PropsFileReader {
 
                 // override dbname with given value
                 if (PropsFileReader.cmdVars.dbName !== "" && token.endsWith("_MYSQL_DB")) {
-                    Logger.log(LogLevel.INFO, `Overriding macro ${token} with the value of cmd line arg "--dbName${PropsFileReader.cmdVars.dbName}" for fleetviewer`);
+                    Logger.log(LogLevel.INFO, `Overriding macro ${token} with the value of cmd line arg "--dbName=${PropsFileReader.cmdVars.dbName}" for fleetviewer`);
                     props['macro'][macroIndex]['replacement'] = PropsFileReader.cmdVars.dbName
                 } else {
                     PropsFileReader.processMacroPart(props, macroIndex);

--- a/simpleui-server/src/props-file-reader.ts
+++ b/simpleui-server/src/props-file-reader.ts
@@ -41,7 +41,7 @@ export class PropsFileReader {
         xmlInFile: '',
         jsonOutFile: '',
         zmqHostname: '',
-        DbName: '',
+        dbName: '',
         themeName: '',
     };
 
@@ -253,9 +253,9 @@ export class PropsFileReader {
                 props['macro'][macroIndex]['property'] = property;
 
                 // override dbname with given value
-                if (PropsFileReader.cmdVars.DbName !== "" && token.endsWith("_MYSQL_DB")) {
-                    Logger.log(LogLevel.INFO, `Overriding macro ${token} with the value of cmd line arg "--DbName ${PropsFileReader.cmdVars.DbName}"`);
-                    props['macro'][macroIndex]['replacement'] = PropsFileReader.cmdVars.DbName
+                if (PropsFileReader.cmdVars.dbName !== "" && token.endsWith("_MYSQL_DB")) {
+                    Logger.log(LogLevel.INFO, `Overriding macro ${token} with the value of cmd line arg "--dbName${PropsFileReader.cmdVars.dbName}" for fleetviewer`);
+                    props['macro'][macroIndex]['replacement'] = PropsFileReader.cmdVars.dbName
                 } else {
                     PropsFileReader.processMacroPart(props, macroIndex);
                 }

--- a/simpleui-server/src/simpleui-server.ts
+++ b/simpleui-server/src/simpleui-server.ts
@@ -72,7 +72,7 @@ export class SimpleUIServer {
             props.appTheme.name = cmdVars.themeName;
         }
         if (cmdVars.dbName) {
-            Logger.log(LogLevel.INFO, `Overriding Parameters App DB with the value of command line arg "--dbName=${cmdVars.themeName}"`);
+            Logger.log(LogLevel.INFO, `Overriding Parameters App DB with the value of command line arg "--dbName=${cmdVars.dbName}"`);
             let appLinks = props.appLink;
             appLinks.forEach( (link) => {
                 if (link.url.endsWith('/Parameters.html')) {
@@ -92,7 +92,6 @@ export class SimpleUIServer {
                 '\n  node simpleui-server.js \\' +
                 '\n     --appName=bms \\' +
                 '\n     --webPort=2080' +
-
                 '\n\nExample for running the test:' +
                 '\n  node simpleui-server.js \\' +
                 '\n    --mode=test \\' +
@@ -184,8 +183,7 @@ export class SimpleUIServer {
             }
         }
 
-
-        return cmdVars
+        return cmdVars;
     }
 
     static printServerInfo(cmdVars: any): void {
@@ -214,7 +212,8 @@ export class SimpleUIServer {
 
             // Parse input arguments
             SimpleUIServer.setBinDir(process.argv[1]);
-            const cmdVars = SimpleUIServer.parseCommandLine(process.argv.join(' '));
+            const cli_args = process.argv.slice(2).join(" ");
+            const cmdVars = SimpleUIServer.parseCommandLine(cli_args);
             PropsFileReader.cmdVars = cmdVars;
 
             if (!cmdVars.valid) {

--- a/simpleui-server/src/simpleui-server.ts
+++ b/simpleui-server/src/simpleui-server.ts
@@ -68,9 +68,19 @@ export class SimpleUIServer {
      */
     static addOverrides(cmdVars: CommandArgs, props: any): any {
         if (cmdVars.themeName) {
-            Logger.log(LogLevel.INFO, `Overriding props.appTheme.name (${props.appTheme.name}) with ${cmdVars.themeName}`);
+            Logger.log(LogLevel.INFO, `Overriding props.appTheme.name (${props.appTheme.name}) with the value of command line arg "--themeName=${cmdVars.themeName}"`);
             props.appTheme.name = cmdVars.themeName;
         }
+        if (cmdVars.dbName) {
+            Logger.log(LogLevel.INFO, `Overriding Parameters App DB with the value of command line arg "--dbName=${cmdVars.themeName}"`);
+            let appLinks = props.appLink;
+            appLinks.forEach( (link) => {
+                if (link.url.endsWith('/Parameters.html')) {
+                    link.url = link.url + `?database=${cmdVars.dbName}`;
+                }
+            })
+        }
+
         return props;
     }
 
@@ -98,7 +108,7 @@ export class SimpleUIServer {
             xmlInFile: '',
             jsonOutFile: '',
             zmqHostname: '',
-            DbName: '',
+            dbName: '',
             themeName: '',
         };
 
@@ -159,10 +169,10 @@ export class SimpleUIServer {
         }
 
         // overrides
-        cmdVars.help += '\n    --DbName=       (optional) Overrides the DbName';
-        match = cmdLine.match(/(\W+-D\W+|--DbName=)([^ \t]+)/);
+        cmdVars.help += '\n    --dbName=       (optional) Overrides the dbName';
+        match = cmdLine.match(/(\W+-D\W+|--dbName=)([^ \t]+)/);
         if (match) {
-            cmdVars.DbName = match[2];
+            cmdVars.dbName = match[2];
         }
         cmdVars.help += '\n    --themeName=       (optional) Overrides the themeName. Must be either SimpleUiBlue, SimpleUiPurple, SimpleUiSea, or SimpleUiPeach';
         match = cmdLine.match(/(\W+-t\W+|--themeName=)([^ \t]+)/);

--- a/simpleui-server/src/simpleui-server.ts
+++ b/simpleui-server/src/simpleui-server.ts
@@ -78,7 +78,6 @@ export class SimpleUIServer {
         const cmdVars: CommandArgs = <CommandArgs> {
             valid: true,
             help: '\nSyntax:\n\n', // Each arg help is appended in arg definition
-            override: false,
             examples: '\n\nExample for running as a daemon:' +
                 '\n  node simpleui-server.js \\' +
                 '\n     --appName=bms \\' +
@@ -164,14 +163,12 @@ export class SimpleUIServer {
         match = cmdLine.match(/(\W+-D\W+|--DbName=)([^ \t]+)/);
         if (match) {
             cmdVars.DbName = match[2];
-            cmdVars.override = true;
         }
         cmdVars.help += '\n    --themeName=       (optional) Overrides the themeName. Must be either SimpleUiBlue, SimpleUiPurple, SimpleUiSea, or SimpleUiPeach';
         match = cmdLine.match(/(\W+-t\W+|--themeName=)([^ \t]+)/);
         if (match) {
             if ( ["SimpleUiBlue", "SimpleUiPurple", "SimpleUiSea", "SimpleUiPeach"].includes(match[2]) ) {
                 cmdVars.themeName = match[2];
-                cmdVars.override = true;
             } else {
                 Logger.log(LogLevel.WARNING, `themeName ${match[2]} is not valid, using themeName in ui.properties`);
             }

--- a/simpleui-server/src/simpleui-server.ts
+++ b/simpleui-server/src/simpleui-server.ts
@@ -109,6 +109,7 @@ export class SimpleUIServer {
             zmqHostname: '',
             dbName: '',
             themeName: '',
+            mock: false
         };
 
         cmdVars.help += '\n    -m or --mode=     (optional) the mode (daemon or test) - defaults to daemon';
@@ -165,6 +166,10 @@ export class SimpleUIServer {
         } else {
             cmdVars.valid = false;
             cmdVars.errors += `a ZMQ hostname is required. \n`;
+        }
+
+        if (cmdLine.includes("--mock")) {
+            cmdVars.mock = true;
         }
 
         // overrides

--- a/simpleui-server/src/sui_zmq.ts
+++ b/simpleui-server/src/sui_zmq.ts
@@ -156,8 +156,6 @@ export class zmq_wrapper {
 
         process.on('SIGTERM', () => this.handleApplicationExit('SIGTERM'));
 
-        process.on('SIGWINCH', () => this.handleApplicationExit('SIGWINCH'));
-
     }
 
     get(port: number) {

--- a/simpleui-server/src/sui_zmq.ts
+++ b/simpleui-server/src/sui_zmq.ts
@@ -140,13 +140,15 @@ export class ZMQ_Socket_Wrapper {
  */
 export class zmq_wrapper {
     socket_map: Map<number, ZMQ_Socket_Wrapper>;
+    hostname: string;
 
-    constructor(port_list: Array<number>) {
+    constructor(port_list: Array<number>, hostname: string) {
         this.socket_map = new Map();
+        this.hostname = hostname;
 
 
         port_list.forEach( (port) => {
-            const zmq_wrapper_instance = new ZMQ_Socket_Wrapper('svcmachineapps', port);
+            const zmq_wrapper_instance = new ZMQ_Socket_Wrapper(hostname, port);
             this.socket_map.set(port, zmq_wrapper_instance);
         });
 

--- a/web/html/ParamsApp/Parameters.html
+++ b/web/html/ParamsApp/Parameters.html
@@ -47,19 +47,44 @@
         </table>
 
         </div>
-        
+
         <script>
             var app = angular.module('paramsApp', ['ngMaterial']);
             app.controller('paramsCtrl', function ($scope, $http, $mdDialog) {
 
                 $scope.debug = false;
 
-                $http.get( "php/NewParams.php" )
+
+                const url_params = new URLSearchParams(window.location.search);
+                let php_request_url = "php/NewParams.php";
+
+                if (window.location.search) {
+                    php_request_url += window.location.search;
+                    console.debug(`Requesting ${php_request_url}`);
+                }
+
+                $http.get( php_request_url )
                        .then (function ( response )  {
-                            $scope.params = response.data.records;
-                            $scope.subsystems = get_unique_subsystems( response.data.records );
-                            $scope.SubsysSel = $scope.subsystems[0];
-                            $scope.categories = get_unique_categories(response.data.records);
+                            // response or query failed
+                            if (response.status != 200) {
+                                let alert_msg = `ParamsApp got an error. Request got status code ${response.status}`;
+                                console.error(alert_msg, response);
+                                alert(alert_msg);
+                            }
+                            else if (response.data.hasOwnProperty('error')) {
+                                let err_code = response.data.error.code;
+                                let err_msg = response.data.error.msg;
+                                let err_context = response.data.error.context;
+                                let alert_msg = `ParamsApp got an error.\nCode: ${err_code}\nMsg: ${err_msg}\nContext: ${err_context}`;
+                                console.error(alert_msg, response);
+                                alert(alert_msg);
+                            } else {
+                                $scope.params = response.data.records;
+                                $scope.subsystems = get_unique_subsystems(response.data.records);
+                                $scope.SubsysSel = $scope.subsystems[0];
+                                $scope.categories = get_unique_categories(response.data.records);
+                            }
+
                         });
 
                 $scope.paramRow = {
@@ -132,7 +157,7 @@
                         .targetEvent(ev)
                     );
                 };
-           
+
                 $scope.addNewParamValues = function (newParamValues)  {
                     var postStatus;
 	                data = { 'newParamValues': newParamValues };
@@ -250,6 +275,6 @@
            </script>
 
 
-       
+
 </BODY>
 </HTML>

--- a/web/html/ParamsApp/Parameters.html
+++ b/web/html/ParamsApp/Parameters.html
@@ -53,16 +53,15 @@
             app.controller('paramsCtrl', function ($scope, $http, $mdDialog) {
 
                 $scope.debug = false;
-                let php_request_url = "php/NewParams.php";
+                let php_get_request_url = "php/NewParams.php";
 
                 // append url params to php url if needed
-                const url_params = new URLSearchParams(window.location.search);
                 if (window.location.search) {
-                    php_request_url += window.location.search;
-                    console.debug(`Requesting ${php_request_url}`);
+                    php_get_request_url += window.location.search;
+                    console.debug(`Requesting ${php_get_request_url}`);
                 }
 
-                $http.get( php_request_url )
+                $http.get( php_get_request_url )
                        .then (function ( response )  {
                             // response failed
                             if (response.status != 200) {
@@ -170,7 +169,16 @@
 	                $http.get('php/InsertParamValues.php', data)
 	                */
 	                var config={'responseType':'json'};
-	                $http.post('php/InsertParamValues.php', data, config)
+
+                    let php_post_request_url = 'php/InsertParamValues.php';
+
+                    // append url params to php url if needed
+                    if (window.location.search) {
+                        php_post_request_url += window.location.search;
+                        console.debug(`Requesting ${php_post_request_url}`);
+                    }
+
+	                $http.post(php_post_request_url, data, config)
 	                .then(function (data, status, headers, config) {
 	                    $scope.content = status + ' - ' + data;
                         postStatus = 0;

--- a/web/html/ParamsApp/Parameters.html
+++ b/web/html/ParamsApp/Parameters.html
@@ -19,7 +19,7 @@
         <select  ng-model="SubsysSel" ng-options="subsys for subsys in subsystems" ></select>
         <table>
             <tr ng-repeat="cat in categories | filter : { 'subsystem' : SubsysSel }" ng-controller="catController as catCtrl" >
-                <td  ng-style="catLike">{{ cat.category }} <span ng-click="catShow()">{{showSelector}}</span>
+                <td  ng-style="catLike">{{ cat.category }} <span ng-click="catShow()">{{ showSelector }}</span>
                     <table  ng-show = "showMe">
                         <tr >
                             <th></th>
@@ -53,11 +53,10 @@
             app.controller('paramsCtrl', function ($scope, $http, $mdDialog) {
 
                 $scope.debug = false;
-
-
-                const url_params = new URLSearchParams(window.location.search);
                 let php_request_url = "php/NewParams.php";
 
+                // append url params to php url if needed
+                const url_params = new URLSearchParams(window.location.search);
                 if (window.location.search) {
                     php_request_url += window.location.search;
                     console.debug(`Requesting ${php_request_url}`);
@@ -65,24 +64,29 @@
 
                 $http.get( php_request_url )
                        .then (function ( response )  {
-                            // response or query failed
+                            // response failed
                             if (response.status != 200) {
-                                let alert_msg = `ParamsApp got an error. Request got status code ${response.status}`;
+                                const alert_msg = `ParamsApp got an error. Request got status code ${response.status} ${response.statusText}`;
+                                console.error(alert_msg, response);
+                                alert(alert_msg);
+                            } // query failed
+                            else if (response.data.hasOwnProperty('error')) {
+                                const err_code = response.data?.error?.code;
+                                const err_msg = response.data?.error?.msg;
+                                const err_context = response.data?.error?.context;
+                                const alert_msg = `ParamsApp got an error.\nCode: ${err_code}\nMsg: ${err_msg}\nContext: ${err_context}`;
                                 console.error(alert_msg, response);
                                 alert(alert_msg);
                             }
-                            else if (response.data.hasOwnProperty('error')) {
-                                let err_code = response.data.error.code;
-                                let err_msg = response.data.error.msg;
-                                let err_context = response.data.error.context;
-                                let alert_msg = `ParamsApp got an error.\nCode: ${err_code}\nMsg: ${err_msg}\nContext: ${err_context}`;
-                                console.error(alert_msg, response);
-                                alert(alert_msg);
-                            } else {
+                            else if (response.status == 200 && response.data) {
+                                // got good response with data
                                 $scope.params = response.data.records;
                                 $scope.subsystems = get_unique_subsystems(response.data.records);
                                 $scope.SubsysSel = $scope.subsystems[0];
                                 $scope.categories = get_unique_categories(response.data.records);
+                            } else {
+                                console.error('Got odd response from backend', response);
+                                alert("Got an odd response from the backend. Check the javascript console for more information.");
                             }
 
                         });

--- a/web/html/ParamsApp/php/DbSchemaDefs.php
+++ b/web/html/ParamsApp/php/DbSchemaDefs.php
@@ -200,16 +200,19 @@ function createRequiredDbEntities($dbName, $user, $pw, $dbHost, $quiet = false)
     /* Define any missing req table */
     foreach($reqTables as $tableName => $tableDef) {
 
-        $query = sprintf(TABLE_EXISTS_QUERY, $dbName, $tableName);		// create a query to check if the db and table exist
-        $result = $conn->query($query); 								// perform query
+        $query = sprintf(TABLE_EXISTS_QUERY, $dbName, $tableName);
+        $result = $conn->query($query);
 		if (! $result) {
 			return false;
 		}
         $rs = $result->fetch_array(MYSQLI_ASSOC);
 
-		if ($rs['tableExists'] != "0") {
+		if ($rs['tableExists'] == "0") {
+            $return .= $tableName . " (created table)\n";
+            $result = $conn->query($tableDef);
+		} else {
             $return .= $tableName . " (preexisting table)\n";
-        }
+		}
     }
 
     /* Define any missing req view */

--- a/web/html/ParamsApp/php/NewParams.php
+++ b/web/html/ParamsApp/php/NewParams.php
@@ -3,9 +3,7 @@ header("Access-Control-Allow-Origin: *");
 header("Content-Type: application/json; charset=UTF-8");
 require_once "ParamHelper.php";
 require_once "DbSchemaDefs.php";
-//require_once "sLogger.php";
 
-//$log->logData(LOG_INFO, "NewParams.php");
 
 function writeInvalidRowError($rowLabel, $row, $missingKey) {
     $errorContext = $rowLabel . ":\n";
@@ -68,6 +66,12 @@ function isSameResource($prevRow, $currRow) {
 /* Create required Database definitions if necessary */
 $tableList = createRequiredDbEntities($MYSQL_DB, $MYSQL_USER, $MYSQL_PWD, $MYSQL_HOST, true);
 
+if (! $tableList) {
+    $err_context = "DB -> " . $MYSQL_DB . " Table -> " . $DataParameterTable;
+    writeError("1", "", "Unable to find DB and/or Table", $err_context);
+    exit();
+}
+
 /* Continue */
 $fields = array("subsystem", "catDisplayOrder", "paramDisplayOrder", "category", "paramName", "type", "min", "max", "description", "detail", "resource", "timestamp", "value", "user");
 $outerParamFields = array("subsystem", "catDisplayOrder", "paramDisplayOrder", "category", "paramName", "type", "min", "max", "description", "detail", "resource");
@@ -105,16 +109,6 @@ if (! empty($_GET['DEBUG'])) {
     $DT9 = "|9|";
 }
 
-// $query = "
-// SELECT apd.subsystem, apd.catDisplayOrder, apd.paramDisplayOrder, apd.category,
-// apd.paramName, apd.type, apd.min, apd.max, apd.description, apd.detail,
-// p.resource, p.`timestamp`, p.value, p.`user`
-// FROM `AbstractParameterByCategory` AS apd
-// INNER JOIN `$DataParameterTable` AS p
-// ON apd.paramName = p.name
-// AND apd.subsystem = p.subsystem
-// AND apd.category = p.category
-// ORDER BY apd.subsystem, apd.catDisplayOrder, apd.paramDisplayOrder, apd.category, p.name, p.resource asc, p.`timestamp` desc";
 
 $query = "SELECT apd.subsystem, apd.catDisplayOrder, apd.paramDisplayOrder, apd.category,";
 $query .= " apd.paramName, apd.type, apd.min, apd.max, apd.description, apd.detail,";

--- a/web/html/ParamsApp/php/NewParams.php
+++ b/web/html/ParamsApp/php/NewParams.php
@@ -109,16 +109,17 @@ if (! empty($_GET['DEBUG'])) {
     $DT9 = "|9|";
 }
 
+$query = "
+SELECT apd.subsystem, apd.catDisplayOrder, apd.paramDisplayOrder, apd.category,
+apd.paramName, apd.type, apd.min, apd.max, apd.description, apd.detail,
+p.resource, p.`timestamp`, p.value, p.`user`
+FROM `AbstractParameterByCategory` AS apd
+			INNER JOIN `$DataParameterTable` AS p
+				ON apd.paramName = p.name
+				AND apd.subsystem = p.subsystem
+				AND apd.category = p.category
+ORDER BY apd.subsystem, apd.catDisplayOrder, apd.paramDisplayOrder, apd.category, p.name, p.resource asc, p.`timestamp` desc";
 
-$query = "SELECT apd.subsystem, apd.catDisplayOrder, apd.paramDisplayOrder, apd.category,";
-$query .= " apd.paramName, apd.type, apd.min, apd.max, apd.description, apd.detail,";
-$query .= " p.resource, p.`timestamp`, p.value, p.`user`";
-$query .= " FROM `AbstractParameterByCategory` AS apd";
-$query .= " INNER JOIN `$DataParameterTable` AS p";
-$query .= " ON apd.paramName = p.name";
-$query .= " AND apd.subsystem = p.subsystem";
-$query .= " AND apd.category = p.category";
-$query .= " ORDER BY apd.subsystem, apd.catDisplayOrder, apd.paramDisplayOrder, apd.category, p.name, p.resource asc, p.`timestamp` desc";
 
 
 $conn = new mysqli($MYSQL_HOST, $MYSQL_USER, $MYSQL_PWD, $MYSQL_DB);

--- a/web/html/ParamsApp/php/NewParams.php
+++ b/web/html/ParamsApp/php/NewParams.php
@@ -70,7 +70,7 @@ $fields = array("subsystem", "catDisplayOrder", "paramDisplayOrder", "category",
 $outerParamFields = array("subsystem", "catDisplayOrder", "paramDisplayOrder", "category", "paramName", "type", "min", "max", "description", "detail", "resource");
 $resourceField = "resource";
 
-    
+
 $category = "";
 if (! empty($_GET['category'])) {
     $category = $_GET['category'];

--- a/web/html/ParamsApp/php/NewParams.php
+++ b/web/html/ParamsApp/php/NewParams.php
@@ -3,6 +3,9 @@ header("Access-Control-Allow-Origin: *");
 header("Content-Type: application/json; charset=UTF-8");
 require_once "ParamHelper.php";
 require_once "DbSchemaDefs.php";
+//require_once "sLogger.php";
+
+//$log->logData(LOG_INFO, "NewParams.php");
 
 function writeInvalidRowError($rowLabel, $row, $missingKey) {
     $errorContext = $rowLabel . ":\n";
@@ -76,6 +79,7 @@ if (! empty($_GET['category'])) {
     $category = $_GET['category'];
 }
 
+
 // Define empty defaults for debug trace flags that help understand where in the flow various pieces of data are created
 $DT0 = "";
 $DT1 = "";
@@ -101,16 +105,27 @@ if (! empty($_GET['DEBUG'])) {
     $DT9 = "|9|";
 }
 
-$query = "
-SELECT apd.subsystem, apd.catDisplayOrder, apd.paramDisplayOrder, apd.category,
-apd.paramName, apd.type, apd.min, apd.max, apd.description, apd.detail,
-p.resource, p.`timestamp`, p.value, p.`user`
-FROM `AbstractParameterByCategory` AS apd
-			INNER JOIN `$DataParameterTable` AS p
-				ON apd.paramName = p.name
-				AND apd.subsystem = p.subsystem
-				AND apd.category = p.category
-ORDER BY apd.subsystem, apd.catDisplayOrder, apd.paramDisplayOrder, apd.category, p.name, p.resource asc, p.`timestamp` desc";
+// $query = "
+// SELECT apd.subsystem, apd.catDisplayOrder, apd.paramDisplayOrder, apd.category,
+// apd.paramName, apd.type, apd.min, apd.max, apd.description, apd.detail,
+// p.resource, p.`timestamp`, p.value, p.`user`
+// FROM `AbstractParameterByCategory` AS apd
+// INNER JOIN `$DataParameterTable` AS p
+// ON apd.paramName = p.name
+// AND apd.subsystem = p.subsystem
+// AND apd.category = p.category
+// ORDER BY apd.subsystem, apd.catDisplayOrder, apd.paramDisplayOrder, apd.category, p.name, p.resource asc, p.`timestamp` desc";
+
+$query = "SELECT apd.subsystem, apd.catDisplayOrder, apd.paramDisplayOrder, apd.category,";
+$query .= " apd.paramName, apd.type, apd.min, apd.max, apd.description, apd.detail,";
+$query .= " p.resource, p.`timestamp`, p.value, p.`user`";
+$query .= " FROM `AbstractParameterByCategory` AS apd";
+$query .= " INNER JOIN `$DataParameterTable` AS p";
+$query .= " ON apd.paramName = p.name";
+$query .= " AND apd.subsystem = p.subsystem";
+$query .= " AND apd.category = p.category";
+$query .= " ORDER BY apd.subsystem, apd.catDisplayOrder, apd.paramDisplayOrder, apd.category, p.name, p.resource asc, p.`timestamp` desc";
+
 
 $conn = new mysqli($MYSQL_HOST, $MYSQL_USER, $MYSQL_PWD, $MYSQL_DB);
 

--- a/web/html/ParamsApp/php/ParamHelper.php
+++ b/web/html/ParamsApp/php/ParamHelper.php
@@ -61,16 +61,17 @@ function loadAppProperties()
     $ControlsParamDataPrefix =  $GLOBALS["ControlsParamDataPrefix"] = propOrDefault($ConfigProperties, "Controls.param.data_prefix", "Data");
 
     $GLOBALS["AbstractParameterTable"] = "$ControlsParamAbstractPrefix$ControlsParamTable";
-    $GLOBALS["DataParameterTable"] = "$ControlsParamDataPrefix$ControlsParamTable";
     $GLOBALS['MYSQL_USER'] = $ConfigProperties["DatabaseMgr.MYSQL_USER"];
     $GLOBALS['MYSQL_PWD'] = $ConfigProperties["DatabaseMgr.MYSQL_PWD"];
     $GLOBALS['MYSQL_HOST'] = $ConfigProperties["DatabaseMgr.MYSQL_HOST"];
+    $GLOBALS["MYSQL_DB"] = $ConfigProperties["DatabaseMgr.MYSQL_DB"];
+
 
     // dbName override from simpleui CLI
-    if (! empty($_GET('database'))) {
-        $GLOBALS["MYSQL_DB"] = $_GET('database');
+    if (! empty($_GET['database'])) {
+        $GLOBALS["DataParameterTable"] = $_GET["database"];
     } else {
-        $GLOBALS["MYSQL_DB"] = $ConfigProperties["DatabaseMgr.MYSQL_DB"];
+        $GLOBALS["DataParameterTable"] = "$ControlsParamDataPrefix$ControlsParamTable";
     }
 }
 

--- a/web/html/ParamsApp/php/ParamHelper.php
+++ b/web/html/ParamsApp/php/ParamHelper.php
@@ -66,7 +66,6 @@ function loadAppProperties()
     $GLOBALS['MYSQL_USER'] = $ConfigProperties["DatabaseMgr.MYSQL_USER"];
     $GLOBALS['MYSQL_PWD'] = $ConfigProperties["DatabaseMgr.MYSQL_PWD"];
     $GLOBALS['MYSQL_HOST'] = $ConfigProperties["DatabaseMgr.MYSQL_HOST"];
-    $GLOBALS["MYSQL_DB"] = $ConfigProperties["DatabaseMgr.MYSQL_DB"];
 
     // dbName override from simpleui CLI
     if (! empty($_GET['database'])) {

--- a/web/html/ParamsApp/php/ParamHelper.php
+++ b/web/html/ParamsApp/php/ParamHelper.php
@@ -62,10 +62,16 @@ function loadAppProperties()
 
     $GLOBALS["AbstractParameterTable"] = "$ControlsParamAbstractPrefix$ControlsParamTable";
     $GLOBALS["DataParameterTable"] = "$ControlsParamDataPrefix$ControlsParamTable";
-    $GLOBALS['MYSQL_DB'] = $ConfigProperties["DatabaseMgr.MYSQL_DB"];
     $GLOBALS['MYSQL_USER'] = $ConfigProperties["DatabaseMgr.MYSQL_USER"];
     $GLOBALS['MYSQL_PWD'] = $ConfigProperties["DatabaseMgr.MYSQL_PWD"];
     $GLOBALS['MYSQL_HOST'] = $ConfigProperties["DatabaseMgr.MYSQL_HOST"];
+
+    // dbName override from simpleui CLI
+    if (! empty($_GET('database'))) {
+        $GLOBALS["MYSQL_DB"] = $_GET('database');
+    } else {
+        $GLOBALS["MYSQL_DB"] = $ConfigProperties["DatabaseMgr.MYSQL_DB"];
+    }
 }
 
 loadAppProperties();

--- a/web/html/ParamsApp/php/ParamHelper.php
+++ b/web/html/ParamsApp/php/ParamHelper.php
@@ -60,18 +60,19 @@ function loadAppProperties()
     $ControlsParamAbstractPrefix = $GLOBALS["ControlsParamAbstractPrefix"] = propOrDefault($ConfigProperties, "Controls.param.abstract_prefix", "Abstract");
     $ControlsParamDataPrefix =  $GLOBALS["ControlsParamDataPrefix"] = propOrDefault($ConfigProperties, "Controls.param.data_prefix", "Data");
 
+    $GLOBALS["DataParameterTable"] = "$ControlsParamDataPrefix$ControlsParamTable";
     $GLOBALS["AbstractParameterTable"] = "$ControlsParamAbstractPrefix$ControlsParamTable";
+
     $GLOBALS['MYSQL_USER'] = $ConfigProperties["DatabaseMgr.MYSQL_USER"];
     $GLOBALS['MYSQL_PWD'] = $ConfigProperties["DatabaseMgr.MYSQL_PWD"];
     $GLOBALS['MYSQL_HOST'] = $ConfigProperties["DatabaseMgr.MYSQL_HOST"];
     $GLOBALS["MYSQL_DB"] = $ConfigProperties["DatabaseMgr.MYSQL_DB"];
 
-
     // dbName override from simpleui CLI
     if (! empty($_GET['database'])) {
-        $GLOBALS["DataParameterTable"] = $_GET["database"];
+        $GLOBALS['MYSQL_DB'] = $_GET['database'];
     } else {
-        $GLOBALS["DataParameterTable"] = "$ControlsParamDataPrefix$ControlsParamTable";
+        $GLOBALS['MYSQL_DB'] = $ConfigProperties["DatabaseMgr.MYSQL_DB"];
     }
 }
 


### PR DESCRIPTION
This pull request includes an override option for `themeName`, and `dbName` via cli. A required `zmqHostname` argument was also added. 

`--themeName`

`--dbName`

`--zmqHostname`


It also includes some error handling for the params app. As well as removed the `SIGWINCH` handler from `sui_zmq.ts`



# Questions
- Working with this issue and the limited amount of tabs issue, I realized that we do a lot of type checking and `if typeof props.value != undefined` operations throughout the simpleui codebase. What are your guy's thoughts on creating a props class or interface? I believe it would cut down on a lot of repeated code (mostly type checking) throught the codebase