### PR TITLE
Allow multiple wildcard statements in single line in ui.properties

### DIFF
--- a/run-dev-env.bash
+++ b/run-dev-env.bash
@@ -7,6 +7,7 @@ install_script=install-script.bash
 for arg in "$@"
 do
     if [ "$arg" == "debugserver" ]; then
+        echo "--- DEBUG MODE ---"
         install_script=install-script-debug-simpleui-server.bash
     fi
 done

--- a/simpleui-server/src/props-file-reader.ts
+++ b/simpleui-server/src/props-file-reader.ts
@@ -171,14 +171,11 @@ export class PropsFileReader {
     static replaceMacros(props, value) {
         if (props['macro'] instanceof Array) {
             props['macro'].forEach(macro => {
-                if (   (macro instanceof Object)
-                    && (typeof macro['token'] === 'string')
-                    && (typeof macro['replacement'] === 'string') ) {
+                if (   (macro instanceof Object) && (typeof macro['token'] === 'string') && (typeof macro['replacement'] === 'string') ) {
 
                     const searchString = '${' + macro['token'] + '}';
                     const replacement = macro['replacement'];
-                    value = value.replace(searchString, replacement)
-                        .replace('{{index}}', '((index))');
+                    value = ServerUtil.replaceAllOccurences(value, searchString, replacement).replace('{{index}}', '((index))');
                 }
             });
         }
@@ -353,6 +350,7 @@ export class PropsFileReader {
                         props[key][index]['index'] = (keyIndex - 1).toString();
                         props[key][index]['id'] = `${key}-${index + 1}`;
                         props[key][index][subKey] = PropsFileReader.replaceMacros(props, value);
+                        let wwwwww = props[key][index][subKey]
                     } else {
                         props[key][index]['index'] = index.toString();
                         props[key][index]['id'] = `${key}-${index + 1}`;

--- a/simpleui-server/src/props-file-reader.ts
+++ b/simpleui-server/src/props-file-reader.ts
@@ -350,7 +350,6 @@ export class PropsFileReader {
                         props[key][index]['index'] = (keyIndex - 1).toString();
                         props[key][index]['id'] = `${key}-${index + 1}`;
                         props[key][index][subKey] = PropsFileReader.replaceMacros(props, value);
-                        let wwwwww = props[key][index][subKey]
                     } else {
                         props[key][index]['index'] = index.toString();
                         props[key][index]['id'] = `${key}-${index + 1}`;

--- a/simpleui-server/src/server-util.ts
+++ b/simpleui-server/src/server-util.ts
@@ -19,6 +19,18 @@ export class ServerUtil {
     }
 
 
+    /**
+     * replaces all occurences of 'search' with 'replacement' in 'input'
+     * @param input
+     * @param search
+     * @param replace
+     * @returns
+     */
+    static replaceAllOccurences(input: string, search: string, replacement: string) {
+        return input.split(search).join(replacement);
+    }
+
+
     static htmlspecialchars(s: string) {
         const retVal =
             s.replace(/&/g, '&amp;')


### PR DESCRIPTION
Previously in `ui.properties`, if a line had multiple `${MACRO}` values, then only the first value would be evaluated. This merge request fixes that issue

### Before
`${MACRO_1} ----- ${MACRO_1}` evaluates to `MACRO_1_VALUE ----- ${MACRO_1}`

### After
`${MACRO_1} ----- ${MACRO_1}` evaluates to `MACRO_1_VALUE ----- MACRO_1_VALUE `