### PR TITLE
add CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,3 @@
+# Only these two accounts can review and accept merge request across all (*) files and folders
+# read more about CODEOWNERS here: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+* @zbeucler-largo @jscarsdale1


### PR DESCRIPTION
Adds a CODEOWNERS file. This file makes sure that only certain accounts can approve merge requests