### PR TITLE
Fix tables collaping when link clicked

### DIFF
--- a/base_app/src/app/dataset-tables/dataset-table.html
+++ b/base_app/src/app/dataset-tables/dataset-table.html
@@ -8,9 +8,10 @@
                             <table>
                                 <thead class="dataSetSizerHead">
                                 <tr>
-                                    <th colspan="2" class="tableTitle" align="center" [uid]="_dataset.u_id" (click)="toggleTableDisplay()">
+                                    <th colspan="2" class="tableTitle" align="center" [uid]="_dataset.u_id" >
                                         <div [className]="this._hidden ? 'sectionClosed':'sectionOpened'"
                                             [title]="fixNL(_dataset.desc)"
+                                            (click)="toggleTableDisplay()"
                                         >&nbsp;</div>
                                         <span *ngIf="!_dataset.url">{{ getTitle() }}</span
                                         >&nbsp;<a *ngIf="_dataset.url" target="_blank"  href={{_dataset.url}}

--- a/simpleui-server/src/sui_data.ts
+++ b/simpleui-server/src/sui_data.ts
@@ -677,8 +677,6 @@ export class SuiData {
         }
 
         if (res) {
-            const broken_links = SuiData.checkForBrokenOverlayFiles(sJson);
-            //console.log('------------- Broken links', broken_links)
             res.send(sJson);
         }
         return;


### PR DESCRIPTION
Dataset tables used to collapse when the URL was clicked. Now, dataset tables only collapse when the collapse button is pressed