### PR TITLE
Zmq debug info

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,24 +34,6 @@ RUN apt-get update && DEBIAN_FRONTEND="noninteractive" apt-get install -y \
     wget \
     && rm -rf /var/lib/apt/lists/*
 
-# ZMQ
-RUN wget --no-check-certificate --quiet \
-    https://github.com/zeromq/libzmq/releases/download/v4.3.2/zeromq-4.3.2.tar.gz && \
-    tar -xzf zeromq-4.3.2.tar.gz && \
-    cd zeromq-4.3.2 && \
-    ./configure && \
-    make -j$(nproc) && \
-    make install && \
-    cd .. && \
-    rm -rf ./zeromq-4.3.2 zeromq-4.3.2.tar.gz && \
-    ldconfig
-
-# php-zmq
-RUN git clone https://github.com/mkoppanen/php-zmq.git && \
-    cd php-zmq && \
-    phpize && ./configure && make install -j$(nproc) && \
-    cd .. && \
-    rm -rf ./php-zmq
 
 # Tini init-system
 ENV TINI_VERSION v0.19.0

--- a/base_app/src/app/app.component.css
+++ b/base_app/src/app/app.component.css
@@ -69,3 +69,17 @@
     -webkit-border-radius:20px;
     -moz-border-radius:20px;
 }
+
+.indicatorReconnecting {
+    background-color: yellow;
+    position: relative;
+    top: 0;
+    right: 0;
+    border: 3px solid #000;
+    height:40px;
+    width: 40px;
+    font-family: Tahoma, sans-serif;
+    font-size: 8px;
+    -webkit-border-radius:20px;
+    -moz-border-radius:20px;
+}

--- a/base_app/src/app/app.component.ts
+++ b/base_app/src/app/app.component.ts
@@ -713,7 +713,7 @@ export class AppComponent implements OnInit, AfterViewInit /*, OnChanges */ {
                     url: `${AppComponent.getDataTabPath(tab.dataUrl, tab.index, tab_hash, serverSideJsDebugging)}`,
                     withCredentials: true,
                     crossDomain: true,
-                    timeout: parseInt(this.getProp('ajaxTimeout', '1001'), 10)
+                    timeout: parseInt(this.getProp('ajaxTimeout', '5001'), 10)
                 };
                 const remoteData$ = ajax(ajaxRequest);
                 remoteData$.subscribe(

--- a/base_app/src/app/app.component.ts
+++ b/base_app/src/app/app.component.ts
@@ -757,7 +757,6 @@ export class AppComponent implements OnInit, AfterViewInit /*, OnChanges */ {
             ClientLogger.log('LogRefreshCycleCount', 'Cycle #' + this._refreshCycle + ' completed.');
         } else if (response['ZMQ_error']) {
             const toggleButton = document.getElementById('dbPulse');
-            toggleButton.innerText = "";
             toggleButton.className = "indicatorReconnecting";
             this._tBarProps._serverStatus = "Server reconnecting";
         } else {

--- a/base_app/src/app/app.component.ts
+++ b/base_app/src/app/app.component.ts
@@ -723,7 +723,7 @@ export class AppComponent implements OnInit, AfterViewInit /*, OnChanges */ {
                             this.onTabDataUpdate(tab, res.response);
                             //console.log('requested data...')
                         } else {
-                            console.warn(`Got odd response: ${res.response}`);
+                            console.warn(`Got odd response:`, res);
                         }
                     },
                     err => {
@@ -754,8 +754,10 @@ export class AppComponent implements OnInit, AfterViewInit /*, OnChanges */ {
             this._detectChanges = {'name': tab.name, 'value': true};
             this.updateData(tab, response['Overlay_Summary']);
             ClientLogger.log('LogRefreshCycleCount', 'Cycle #' + this._refreshCycle + ' completed.');
-
+        } else if (response['ZMQ_error']) {
+            document.title = "ZACK!!!"
         } else {
+            console.warn(response)
             ClientLogger.log('LogRefreshCycleCount', 'Cycle #' + this._refreshCycle + ' completed with error (EMPTY RESPONSE).');
         }
     }

--- a/base_app/src/app/app.component.ts
+++ b/base_app/src/app/app.component.ts
@@ -722,7 +722,7 @@ export class AppComponent implements OnInit, AfterViewInit /*, OnChanges */ {
                     url: `${AppComponent.getDataTabPath(tab.dataUrl, tab.index, tab_hash, serverSideJsDebugging)}`,
                     withCredentials: true,
                     crossDomain: true,
-                    timeout:  120 * 1_000  //parseInt(this.getProp('ajaxTimeout', '5001'), 10)
+                    timeout:  5_000  //parseInt(this.getProp('ajaxTimeout', '5001'), 10)
                 };
 
                 // of(ajaxRequest.url).pipe(

--- a/base_app/src/app/app.component.ts
+++ b/base_app/src/app/app.component.ts
@@ -713,7 +713,7 @@ export class AppComponent implements OnInit, AfterViewInit /*, OnChanges */ {
                     url: `${AppComponent.getDataTabPath(tab.dataUrl, tab.index, tab_hash, serverSideJsDebugging)}`,
                     withCredentials: true,
                     crossDomain: true,
-                    timeout: 3 * 1_000  //parseInt(this.getProp('ajaxTimeout', '5001'), 10)
+                    timeout: 60 * 1_000  //parseInt(this.getProp('ajaxTimeout', '5001'), 10)
                 };
                 const remoteData$ = ajax(ajaxRequest);
                 remoteData$.subscribe(

--- a/base_app/src/app/app.component.ts
+++ b/base_app/src/app/app.component.ts
@@ -722,7 +722,7 @@ export class AppComponent implements OnInit, AfterViewInit /*, OnChanges */ {
                     url: `${AppComponent.getDataTabPath(tab.dataUrl, tab.index, tab_hash, serverSideJsDebugging)}`,
                     withCredentials: true,
                     crossDomain: true,
-                    timeout:  2 * 1_000  //parseInt(this.getProp('ajaxTimeout', '5001'), 10)
+                    timeout:  120 * 1_000  //parseInt(this.getProp('ajaxTimeout', '5001'), 10)
                 };
 
                 // of(ajaxRequest.url).pipe(

--- a/base_app/src/app/app.component.ts
+++ b/base_app/src/app/app.component.ts
@@ -570,17 +570,17 @@ export class AppComponent implements OnInit, AfterViewInit /*, OnChanges */ {
         }
         this._refreshRate = Math.max(this._refreshRate, 1000); // Don't allow a refreshRate < 1000 ms
 
-        this.doUpdate(0)
+        //this.doUpdate(0)
 
-        // const updateTimer = interval(this._refreshRate);
+        const updateTimer = interval(this._refreshRate);
 
-        // this._updateSubscription = updateTimer.subscribe(
-        //     cycle => {
-        //         this.doUpdate(cycle);
-        //     },
-        //     err => {
-        //         console.error(`Error in initTabDataUpdates() ajax subscribe callback.`, err);
-        //     });
+        this._updateSubscription = updateTimer.subscribe(
+            cycle => {
+                this.doUpdate(cycle);
+            },
+            err => {
+                console.error(`Error in initTabDataUpdates() ajax subscribe callback.`, err);
+            });
     }
 
     /**
@@ -725,64 +725,64 @@ export class AppComponent implements OnInit, AfterViewInit /*, OnChanges */ {
                     timeout:  2 * 1_000  //parseInt(this.getProp('ajaxTimeout', '5001'), 10)
                 };
 
-                of(ajaxRequest.url).pipe(
-                    concatMap((request: any) => this.http.get(request).pipe(
-                        timeout(ajaxRequest.timeout)
-                    )),
-                    repeatWhen((pause) => {
-                        return pause.pipe(
-                            delay(this._refreshRate),
-                            takeWhile(() => this._tBarProps._serverStatus !== 'updates paused'), // AppComponent._updatesSuspended
-                            concatMap((err) => {
-                                if (err instanceof Error) {
-                                    if (err.name === "TimeoutError") {
-                                        console.error(`Timeout of request (of)`, err);
-                                    } else {
-                                        console.error(`of request error`, err);
-                                    }
-                                    return timer(0); // stop
-                                } else {
-                                    return timer();
-                                }
-                            })
-                        );
-                    })
-                ).subscribe(
-                    (res) => {
-                        if (res) {
-                            tab._pendingRequestExpiration = 0;
-                            this.onTabDataUpdate(tab, res);
-                        } else {
-                            console.warn("got odd response: ", res)
-                        }
-                    },
-                    (err) => {
-                        if (err instanceof Error && err.name === "TimeoutError") {
-                            console.error(`Timeout of request (sub)`, err)
-                        }
-                    }
-                )
-
-                // const remoteData$ = ajax(ajaxRequest);
-                // remoteData$.subscribe(
-                //     res => {
-                //         if (res.status === 200 && typeof res.response === 'object' && (null !== res.response)) {
-                //             tab._pendingRequestExpiration = 0; // Cancel wait
-                //             this.onTabDataUpdate(tab, res.response);
-                //             //console.log('requested data...')
+                // of(ajaxRequest.url).pipe(
+                //     concatMap((request: any) => this.http.get(request).pipe(
+                //         timeout(ajaxRequest.timeout)
+                //     )),
+                //     repeatWhen((pause) => {
+                //         return pause.pipe(
+                //             delay(this._refreshRate),
+                //             takeWhile(() => this._tBarProps._serverStatus !== 'updates paused'), // AppComponent._updatesSuspended
+                //             concatMap((err) => {
+                //                 if (err instanceof Error) {
+                //                     if (err.name === "TimeoutError") {
+                //                         console.error(`Timeout of request (of)`, err);
+                //                     } else {
+                //                         console.error(`of request error`, err);
+                //                     }
+                //                     return timer(0); // stop
+                //                 } else {
+                //                     return timer();
+                //                 }
+                //             })
+                //         );
+                //     })
+                // ).subscribe(
+                //     (res) => {
+                //         if (res) {
+                //             tab._pendingRequestExpiration = 0;
+                //             this.onTabDataUpdate(tab, res);
                 //         } else {
-                //             console.warn(`Got odd response:`, res);
+                //             console.warn("got odd response: ", res)
                 //         }
                 //     },
-                //     err => {
-                //         console.log(`Error in getRemoteTabData() ajax subscribe callback.`);
-                //         try {
-                //             console.log('  name: ' + err.name + ', message: ' + err.message + ', url: ' + err.request.url);
-                //         } catch (err1) {
-                //             console.log('error logging ajax error in getRemoteTabData()');
+                //     (err) => {
+                //         if (err instanceof Error && err.name === "TimeoutError") {
+                //             console.error(`Timeout of request (sub)`, err)
                 //         }
                 //     }
-                // );
+                // )
+
+                const remoteData$ = ajax(ajaxRequest);
+                remoteData$.subscribe(
+                    res => {
+                        if (res.status === 200 && typeof res.response === 'object' && (null !== res.response)) {
+                            tab._pendingRequestExpiration = 0; // Cancel wait
+                            this.onTabDataUpdate(tab, res.response);
+                            //console.log('requested data...')
+                        } else {
+                            console.warn(`Got odd response:`, res);
+                        }
+                    },
+                    err => {
+                        console.log(`Error in getRemoteTabData() ajax subscribe callback.`);
+                        try {
+                            console.log('  name: ' + err.name + ', message: ' + err.message + ', url: ' + err.request.url);
+                        } catch (err1) {
+                            console.log('error logging ajax error in getRemoteTabData()');
+                        }
+                    }
+                );
                 }
 
 

--- a/base_app/src/app/app.component.ts
+++ b/base_app/src/app/app.component.ts
@@ -2,10 +2,14 @@ import {AfterViewInit, Component, EventEmitter, OnInit, Output, ViewChild, isDev
 import {AppProperties, SubscriptionState, TabUI, TitleBarProperties} from './interfaces/props-data';
 import {ajax} from 'rxjs/ajax';
 import {MatTabChangeEvent, MatTabGroup} from '@angular/material/tabs';
-import {interval} from 'rxjs';
+import {interval, of, timer} from 'rxjs';
 import {ClientLogger, LogLevel} from '../tools/logger';
 import {DataSummary} from './interfaces/data-summary';
 import {UTIL} from '../tools/utility';
+
+
+import { concatMap, delay, repeat, repeatWhen, takeWhile, timeout } from 'rxjs/operators'
+import { HttpClient } from '@angular/common/http';
 
 @Component({
     // changeDetection: ChangeDetectionStrategy.OnPush,
@@ -225,6 +229,7 @@ export class AppComponent implements OnInit, AfterViewInit /*, OnChanges */ {
     }
 
     constructor(
+        private http: HttpClient
     ) {
     }
 
@@ -563,15 +568,17 @@ export class AppComponent implements OnInit, AfterViewInit /*, OnChanges */ {
         }
         this._refreshRate = Math.max(this._refreshRate, 1000); // Don't allow a refreshRate < 1000 ms
 
-        const updateTimer = interval(this._refreshRate);
+        this.doUpdate(0)
 
-        this._updateSubscription = updateTimer.subscribe(
-            cycle => {
-                this.doUpdate(cycle);
-            },
-            err => {
-                console.error(`Error in initTabDataUpdates() ajax subscribe callback.`, err);
-            });
+        // const updateTimer = interval(this._refreshRate);
+
+        // this._updateSubscription = updateTimer.subscribe(
+        //     cycle => {
+        //         this.doUpdate(cycle);
+        //     },
+        //     err => {
+        //         console.error(`Error in initTabDataUpdates() ajax subscribe callback.`, err);
+        //     });
     }
 
     /**
@@ -713,28 +720,70 @@ export class AppComponent implements OnInit, AfterViewInit /*, OnChanges */ {
                     url: `${AppComponent.getDataTabPath(tab.dataUrl, tab.index, tab_hash, serverSideJsDebugging)}`,
                     withCredentials: true,
                     crossDomain: true,
-                    timeout:  1_000  //parseInt(this.getProp('ajaxTimeout', '5001'), 10)
+                    timeout:  2 * 1_000  //parseInt(this.getProp('ajaxTimeout', '5001'), 10)
                 };
-                const remoteData$ = ajax(ajaxRequest);
-                remoteData$.subscribe(
-                    res => {
-                        if (res.status === 200 && typeof res.response === 'object' && (null !== res.response)) {
-                            tab._pendingRequestExpiration = 0; // Cancel wait
-                            this.onTabDataUpdate(tab, res.response);
-                            //console.log('requested data...')
+
+                of(ajaxRequest.url).pipe(
+                    concatMap((request: any) => this.http.get(request).pipe(
+                        timeout(ajaxRequest.timeout)
+                    )),
+                    repeatWhen((pause) => {
+                        return pause.pipe(
+                            delay(this._refreshRate),
+                            takeWhile(() => this._tBarProps._serverStatus !== 'updates paused'), // AppComponent._updatesSuspended
+                            concatMap((err) => {
+                                if (err instanceof Error) {
+                                    if (err.name === "TimeoutError") {
+                                        console.error(`Timeout of request (of)`, err);
+                                    } else {
+                                        console.error(`of request error`, err);
+                                    }
+                                    return timer(0); // stop
+                                } else {
+                                    return timer();
+                                }
+                            })
+                        );
+                    })
+                ).subscribe(
+                    (res) => {
+                        if (res) {
+                            tab._pendingRequestExpiration = 0;
+                            this.onTabDataUpdate(tab, res);
                         } else {
-                            console.warn(`Got odd response:`, res);
+                            console.warn("got odd response: ", res)
                         }
                     },
-                    err => {
-                        console.log(`Error in getRemoteTabData() ajax subscribe callback.`);
-                        try {
-                            console.log('  name: ' + err.name + ', message: ' + err.message + ', url: ' + err.request.url);
-                        } catch (err1) {
-                            console.log('error logging ajax error in getRemoteTabData()');
+                    (err) => {
+                        if (err instanceof Error && err.name === "TimeoutError") {
+                            console.error(`Timeout of request (sub)`, err)
                         }
-                    });
-            }
+                    }
+                )
+
+                // const remoteData$ = ajax(ajaxRequest);
+                // remoteData$.subscribe(
+                //     res => {
+                //         if (res.status === 200 && typeof res.response === 'object' && (null !== res.response)) {
+                //             tab._pendingRequestExpiration = 0; // Cancel wait
+                //             this.onTabDataUpdate(tab, res.response);
+                //             //console.log('requested data...')
+                //         } else {
+                //             console.warn(`Got odd response:`, res);
+                //         }
+                //     },
+                //     err => {
+                //         console.log(`Error in getRemoteTabData() ajax subscribe callback.`);
+                //         try {
+                //             console.log('  name: ' + err.name + ', message: ' + err.message + ', url: ' + err.request.url);
+                //         } catch (err1) {
+                //             console.log('error logging ajax error in getRemoteTabData()');
+                //         }
+                //     }
+                // );
+                }
+
+
         }
     }
 
@@ -755,7 +804,7 @@ export class AppComponent implements OnInit, AfterViewInit /*, OnChanges */ {
             this.updateData(tab, response['Overlay_Summary']);
             ClientLogger.log('LogRefreshCycleCount', 'Cycle #' + this._refreshCycle + ' completed.');
         } else if (response['ZMQ_error']) {
-            document.title = "ZACK!!!"
+            document.title = "RECONNECTING"
         } else {
             console.warn(response)
             ClientLogger.log('LogRefreshCycleCount', 'Cycle #' + this._refreshCycle + ' completed with error (EMPTY RESPONSE).');
@@ -834,3 +883,5 @@ export class AppComponent implements OnInit, AfterViewInit /*, OnChanges */ {
     }
 
 }
+
+

--- a/base_app/src/app/app.component.ts
+++ b/base_app/src/app/app.component.ts
@@ -739,6 +739,7 @@ export class AppComponent implements OnInit, AfterViewInit /*, OnChanges */ {
     }
 
     onTabDataUpdate(tab: TabUI, response: any) {
+        this.updateToggleButton()
         if (typeof response === 'object'
                 && typeof response['Data_Summary'] === 'object'
                 && typeof response['Data_Summary']['status'] === 'string'
@@ -759,8 +760,6 @@ export class AppComponent implements OnInit, AfterViewInit /*, OnChanges */ {
             toggleButton.innerText = "";
             toggleButton.className = "indicatorReconnecting";
             this._tBarProps._serverStatus = "Server reconnecting";
-            this._tBarProps._updateTime = "Reconnecting to server";
-
         } else {
             console.warn(`onTabDataUpdate() got data that isnt DataSummary or OverlaySummary`, response);
             ClientLogger.log('LogRefreshCycleCount', 'Cycle #' + this._refreshCycle + ' completed with error (EMPTY RESPONSE).');

--- a/base_app/src/app/app.component.ts
+++ b/base_app/src/app/app.component.ts
@@ -739,7 +739,6 @@ export class AppComponent implements OnInit, AfterViewInit /*, OnChanges */ {
     }
 
     onTabDataUpdate(tab: TabUI, response: any) {
-        this.updateToggleButton()
         if (typeof response === 'object'
                 && typeof response['Data_Summary'] === 'object'
                 && typeof response['Data_Summary']['status'] === 'string'

--- a/base_app/src/app/app.component.ts
+++ b/base_app/src/app/app.component.ts
@@ -713,7 +713,7 @@ export class AppComponent implements OnInit, AfterViewInit /*, OnChanges */ {
                     url: `${AppComponent.getDataTabPath(tab.dataUrl, tab.index, tab_hash, serverSideJsDebugging)}`,
                     withCredentials: true,
                     crossDomain: true,
-                    timeout: 60 * 1_000  //parseInt(this.getProp('ajaxTimeout', '5001'), 10)
+                    timeout:  1_000  //parseInt(this.getProp('ajaxTimeout', '5001'), 10)
                 };
                 const remoteData$ = ajax(ajaxRequest);
                 remoteData$.subscribe(

--- a/base_app/src/app/app.component.ts
+++ b/base_app/src/app/app.component.ts
@@ -713,7 +713,7 @@ export class AppComponent implements OnInit, AfterViewInit /*, OnChanges */ {
                     url: `${AppComponent.getDataTabPath(tab.dataUrl, tab.index, tab_hash, serverSideJsDebugging)}`,
                     withCredentials: true,
                     crossDomain: true,
-                    timeout: parseInt(this.getProp('ajaxTimeout', '5001'), 10)
+                    timeout: 3 * 1_000  //parseInt(this.getProp('ajaxTimeout', '5001'), 10)
                 };
                 const remoteData$ = ajax(ajaxRequest);
                 remoteData$.subscribe(

--- a/base_app/src/app/app.component.ts
+++ b/base_app/src/app/app.component.ts
@@ -713,7 +713,7 @@ export class AppComponent implements OnInit, AfterViewInit /*, OnChanges */ {
                     url: `${AppComponent.getDataTabPath(tab.dataUrl, tab.index, tab_hash, serverSideJsDebugging)}`,
                     withCredentials: true,
                     crossDomain: true,
-                    timeout: parseInt(this.getProp('ajaxTimeout', '5001'), 10)
+                    timeout: parseInt(this.getProp('ajaxTimeout', '1001'), 10)
                 };
                 const remoteData$ = ajax(ajaxRequest);
                 remoteData$.subscribe(

--- a/run-dev-env.bash
+++ b/run-dev-env.bash
@@ -12,6 +12,8 @@ do
     fi
 done
 
+install_script=install-script-debug-simpleui-server.bash
+
 echo "Using SIMPLEUI_TEST_DATA: ${SIMPLEUI_TEST_DATA}"
 
 DEV_TARGET=sample_app
@@ -29,6 +31,25 @@ fi
 echo "${SIMPLEUI_TEST_DATA}/${DEV_TARGET}"
 
 
+# docker run \
+#     -it \
+#     --rm \
+#     --name sui-dev-container \
+#     --mount type=bind,src="${PWD}"/base_app,dst=/usr/src/app/base_app/ \
+#     --mount type=bind,src="${PWD}"/simpleui-server,dst=/usr/src/app/simpleui-server/ \
+#     --mount type=bind,src="${PWD}"/develop_docker/${install_script},dst=/usr/src/app/${install_script} \
+#     --mount type=bind,src="${SIMPLEUI_TEST_DATA}/${DEV_TARGET}",dst=/usr/src/app/base_app/src/assets/ \
+#     --mount type=bind,src="${SIMPLEUI_TEST_DATA}/${DEV_TARGET}",dst=/var/www/simple_ui/ \
+#     --mount type=bind,src="${SIMPLEUI_TEST_DATA}/${DEV_TARGET}"/opt,dst=/opt/ \
+#     -p 4200:4200 \
+#     -p 4100:4100 \
+#     -w /usr/src/app \
+#     sui-dev-image /bin/bash /usr/src/app/${install_script}
+
+
+# This script creates the docker container (sui-dev-container || sui-dev-sim-container) from the dev env image (sui-dev-image)
+
+
 docker run \
     -it \
     --rm \
@@ -41,5 +62,7 @@ docker run \
     --mount type=bind,src="${SIMPLEUI_TEST_DATA}/${DEV_TARGET}"/opt,dst=/opt/ \
     -p 4200:4200 \
     -p 4100:4100 \
-    -w /usr/src/app \
+    -p 9876:9876 \
+    --network=vcharge_sim_1mw_1804_default \
+    -w /usr/src/app/base_app \
     sui-dev-image /bin/bash /usr/src/app/${install_script}

--- a/simpleui-server/src/queue.ts
+++ b/simpleui-server/src/queue.ts
@@ -8,7 +8,7 @@ export class Queue {
 
     constructor() {
         this.elements = [];
-        this.MAX_QUEUE_SIZE = 32;
+        this.MAX_QUEUE_SIZE = 1000;
         this.events = new EventEmitter();
     }
 
@@ -29,7 +29,7 @@ export class Queue {
      * @returns
      */
     dequeue() {
-        return this.isEmpty() ? "Queue Underflow" : this.elements.shift();
+        return this.isEmpty() ? ["Queue Underflow", "Queue Underflow"] : this.elements.shift();
     }
 
     view_all() {

--- a/simpleui-server/src/server-logger.ts
+++ b/simpleui-server/src/server-logger.ts
@@ -22,11 +22,12 @@ export const DisplayLogLevel = {
     'VERBOSE': LogLevel.VERBOSE
 };
 
+
 export class Logger {
 
     public static logLevel = LogLevel.DEBUG;
 
-    public static log(logLevel: LogLevel, message: string) {
+    public static log(logLevel: LogLevel, ...message: any[]) {
         if (logLevel <= Logger.logLevel) {
             console.log(message);
         }

--- a/simpleui-server/src/server-logger.ts
+++ b/simpleui-server/src/server-logger.ts
@@ -29,7 +29,7 @@ export class Logger {
 
     public static log(logLevel: LogLevel, ...message: any[]) {
         if (logLevel <= Logger.logLevel) {
-            console.log(message);
+            console.log(...message);
         }
     }
 

--- a/simpleui-server/src/simpleui-server.ts
+++ b/simpleui-server/src/simpleui-server.ts
@@ -234,7 +234,7 @@ export class SimpleUIServer {
         try {
 
 
-            Logger.logLevel = LogLevel.DEBUG;
+            Logger.logLevel = LogLevel.INFO;
 
             // Parse input arguments
             SimpleUIServer.setBinDir(process.argv[1]);

--- a/simpleui-server/src/simpleui-server.ts
+++ b/simpleui-server/src/simpleui-server.ts
@@ -401,7 +401,7 @@ export class SimpleUIServer {
                         SimpleUIServer.overlay_image_file_names.filter(file => ((file.endsWith("gif")) || (file.endsWith("png"))));
                     } catch (err) { /* no overlay folder */ }
 
-                    SuiData.zmqMap.log_status();
+                    //SuiData.zmqMap.log_status();
                     const props = PropsFileReader.getProps(`${req.params.propsStub}.properties`);
                     SuiData.handleZmqRequest(req, res, props);
                 } catch (err) {
@@ -429,7 +429,7 @@ export class SimpleUIServer {
                 // Replies with data from a zeromq request
                 Logger.log(LogLevel.VERBOSE, `cmd request callback: ${++SimpleUIServer.requestCallbacks}`);
                 try {
-                    SuiData.zmqMap.log_status();
+                    //SuiData.zmqMap.log_status();
                     const props = PropsFileReader.getProps(`${req.params.propsStub}.properties`);
                     SuiData.handleZmqRequest(req, res, props);
                 } catch (err) {

--- a/simpleui-server/src/simpleui-server.ts
+++ b/simpleui-server/src/simpleui-server.ts
@@ -234,7 +234,7 @@ export class SimpleUIServer {
         try {
 
 
-            Logger.logLevel = LogLevel.INFO;
+            Logger.logLevel = LogLevel.DEBUG;
 
             // Parse input arguments
             SimpleUIServer.setBinDir(process.argv[1]);

--- a/simpleui-server/src/simpleui-server.ts
+++ b/simpleui-server/src/simpleui-server.ts
@@ -403,7 +403,7 @@ export class SimpleUIServer {
                         SimpleUIServer.overlay_image_file_names.filter(file => ((file.endsWith("gif")) || (file.endsWith("png"))));
                     } catch (err) { /* no overlay folder */ }
 
-
+                    SuiData.zmqMap.log_status();
                     const props = PropsFileReader.getProps(`${req.params.propsStub}.properties`);
                     SuiData.handleZmqRequest(req, res, props);
                 } catch (err) {
@@ -431,6 +431,7 @@ export class SimpleUIServer {
                 // Replies with data from a zeromq request
                 Logger.log(LogLevel.VERBOSE, `cmd request callback: ${++SimpleUIServer.requestCallbacks}`);
                 try {
+                    SuiData.zmqMap.log_status();
                     const props = PropsFileReader.getProps(`${req.params.propsStub}.properties`);
                     SuiData.handleZmqRequest(req, res, props);
                 } catch (err) {

--- a/simpleui-server/src/simpleui-server.ts
+++ b/simpleui-server/src/simpleui-server.ts
@@ -336,12 +336,12 @@ export class SimpleUIServer {
                         const result = Logger.setLogLevel(req.params.svrCmdValue);
                         res.setHeader('Content-Type', 'application/json');
                         res.setHeader('charset', 'UTF-8');
-                        const svrCmdResponse = `{"svr-util": {` +
-                            `"SvrCmd": "${req.params.svrCmdValue}", ` +
-                            `"CmdValue": "${req.params.svrCmdValue}", ` +
-                            `"Status": "${result}."` +
-                            `}`;
-                        res.send(svrCmdResponse);
+                        const svrCmdResponse = {
+                            "SvrCmd": req.params.svrCmdValue,
+                            "CmdValue": req.params.svrCmdValue,
+                            "Status": result
+                        }
+                        res.json(svrCmdResponse);
                     }
             } catch (err) {
                 const cmd = SuiData.getCmdFromReq(req);

--- a/simpleui-server/src/sui_data.ts
+++ b/simpleui-server/src/sui_data.ts
@@ -248,6 +248,7 @@ export class SuiData {
         }
 
         if (socket.connection_status !== ZMQ_Connection_Status.CONNECTED) {
+            console.log('bounced request')
             res.status(200).json({"ZMQ_error": "reconnecting"});
             return;
         }

--- a/simpleui-server/src/sui_data.ts
+++ b/simpleui-server/src/sui_data.ts
@@ -151,7 +151,7 @@ export class SuiData {
                 sJson length: ${sJson.length}
 
                 Headers:
-                ${res.getHeaders()}\n
+                ${JSON.stringify(res.getHeaders())}\n
 
 
                 `);

--- a/simpleui-server/src/sui_data.ts
+++ b/simpleui-server/src/sui_data.ts
@@ -5,7 +5,7 @@ import {Logger, LogLevel} from './server-logger';
 import {CommandArgs} from './interfaces';
 import {ServerUtil} from './server-util';
 import { SimpleUIServer } from './simpleui-server';
-import { zmq_wrapper } from './sui_zmq';
+import { zmq_wrapper, ZMQ_Connection_Status } from './sui_zmq';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as fastXmlParser from 'fast-xml-parser';
@@ -245,6 +245,11 @@ export class SuiData {
             SuiData.zmqMap.add_socket(zmq_port);
             socket = SuiData.zmqMap.get(zmq_port);
             Logger.log(LogLevel.INFO, `No socket for ZMQ socket with port ${zmq_port}, created new socket`);
+        }
+
+        if (socket.connection_status !== ZMQ_Connection_Status.CONNECTED) {
+            res.status(200).json({"ZMQ_error": "reconnecting"});
+            return;
         }
 
 

--- a/simpleui-server/src/sui_data.ts
+++ b/simpleui-server/src/sui_data.ts
@@ -236,6 +236,18 @@ export class SuiData {
             Logger.log(LogLevel.INFO, `No socket for ZMQ socket with port ${zmq_port}, created new socket`);
         }
 
+        if (socket.reconnect_attempt >= socket.max_reconnect_attempts) {
+            // close socket
+            socket.close();
+            // delete socket
+            SuiData.zmqMap.delete_socket(zmq_port);
+            // recreate socket
+            SuiData.zmqMap.add_socket(zmq_port);
+            socket = SuiData.zmqMap.get(zmq_port);
+            Logger.log(LogLevel.INFO, `Recreated socket ${zmq_port}`);
+        }
+
+
         // get and set connection timeout (is this needed anymore?)
         const timeout = SuiData.propOrDefault(SuiData.uiProps, 'zmqTimeout', 1000);
 

--- a/simpleui-server/src/sui_data.ts
+++ b/simpleui-server/src/sui_data.ts
@@ -120,8 +120,13 @@ export class SuiData {
                 res.send(xmlMetaPrefix + xmlResponse);
                 return;
             } else {
-                res.setHeader('Content-Type', 'application/json');
-                res.setHeader('charset', 'UTF-8');
+                    // svcmachineapps stopped at 11:15
+                try {
+                    res.setHeader('Content-Type', 'application/json');
+                    res.setHeader('charset', 'UTF-8');
+                } catch (err) {
+                    let i = [err, req]
+                }
                 let versionString: any = 'V.xxx';
                 if (req.query.version) {
                     versionString = req.query.version;
@@ -143,6 +148,7 @@ export class SuiData {
                         sJson = JSON.stringify(json);
                     }
                 }
+                console.log(`SENT HTTP RESPONSE!!!!!!!!!!!! Finished: ${res.writableEnded}\n`);
                 res.send(sJson);
             }
         } catch (err) {

--- a/simpleui-server/src/sui_data.ts
+++ b/simpleui-server/src/sui_data.ts
@@ -11,6 +11,26 @@ import * as path from 'path';
 import * as fastXmlParser from 'fast-xml-parser';
 import * as he from 'he';
 
+/**
+
+[Unit]
+Description=Simpleui
+Requires=bms.lce.service
+After=bms.lce.service
+
+[Service]
+ExecStart=/path/to/Simpleui/start
+ExecStop=/path/to/Simpleui/stop
+Restart=always
+
+[Install]
+WantedBy=multi-user.target
+
+ *
+ *
+ *
+ */
+
 
 export interface UiPropStubs {
     uiProp: string,

--- a/simpleui-server/src/sui_data.ts
+++ b/simpleui-server/src/sui_data.ts
@@ -164,16 +164,11 @@ export class SuiData {
                     }
                 }
                 console.log(`SENT HTTP RESPONSE!!!!!!!!!!!!
-                Finished: ${res.writableEnded}\n
-
-                Headers Sent: ${res.headersSent}\n
-
+                Finished: ${res.writableEnded}
+                Headers Sent: ${res.headersSent}
                 sJson length: ${sJson.length}
-
                 Headers:
-                ${JSON.stringify(res.getHeaders())}\n
-
-
+                ${JSON.stringify(res.getHeaders())}
                 `);
                 res.send(sJson);
             }

--- a/simpleui-server/src/sui_data.ts
+++ b/simpleui-server/src/sui_data.ts
@@ -120,13 +120,8 @@ export class SuiData {
                 res.send(xmlMetaPrefix + xmlResponse);
                 return;
             } else {
-                    // svcmachineapps stopped at 11:15
-                try {
-                    res.setHeader('Content-Type', 'application/json');
-                    res.setHeader('charset', 'UTF-8');
-                } catch (err) {
-                    let i = [err, req]
-                }
+                res.setHeader('Content-Type', 'application/json');
+                res.setHeader('charset', 'UTF-8');
                 let versionString: any = 'V.xxx';
                 if (req.query.version) {
                     versionString = req.query.version;
@@ -148,7 +143,18 @@ export class SuiData {
                         sJson = JSON.stringify(json);
                     }
                 }
-                console.log(`SENT HTTP RESPONSE!!!!!!!!!!!! Finished: ${res.writableEnded}\n`);
+                console.log(`SENT HTTP RESPONSE!!!!!!!!!!!!
+                Finished: ${res.writableEnded}\n
+
+                Headers Sent: ${res.headersSent}\n
+
+                sJson length: ${sJson.length}
+
+                Headers:
+                ${res.getHeaders()}\n
+
+
+                `);
                 res.send(sJson);
             }
         } catch (err) {

--- a/simpleui-server/src/sui_data.ts
+++ b/simpleui-server/src/sui_data.ts
@@ -237,9 +237,8 @@ export class SuiData {
 
 
         // get and set connection timeout
-        const timeout = SuiData.propOrDefault(SuiData.uiProps, 'zmqTimeout', 1000);
-
-        socket.set_timeout(timeout);
+        //const timeout = SuiData.propOrDefault(SuiData.uiProps, 'zmqTimeout', 1000);
+        //socket.set_timeout(timeout);
 
         // add res + req pair to socket's queue
         socket.http_queue.enqueue([res, req]);

--- a/simpleui-server/src/sui_data.ts
+++ b/simpleui-server/src/sui_data.ts
@@ -11,25 +11,6 @@ import * as path from 'path';
 import * as fastXmlParser from 'fast-xml-parser';
 import * as he from 'he';
 
-/**
-
-[Unit]
-Description=Simpleui
-Requires=bms.lce.service
-After=bms.lce.service
-
-[Service]
-ExecStart=/path/to/Simpleui/start
-ExecStop=/path/to/Simpleui/stop
-Restart=always
-
-[Install]
-WantedBy=multi-user.target
-
- *
- *
- *
- */
 
 
 export interface UiPropStubs {
@@ -163,13 +144,7 @@ export class SuiData {
                         sJson = JSON.stringify(json);
                     }
                 }
-                console.log(`SENT HTTP RESPONSE!!!!!!!!!!!!
-                Finished: ${res.writableEnded}
-                Headers Sent: ${res.headersSent}
-                sJson length: ${sJson.length}
-                Headers:
-                ${JSON.stringify(res.getHeaders())}
-                `);
+                Logger.log(LogLevel.DEBUG, `Sending HTTP response`);
                 res.send(sJson);
             }
         } catch (err) {
@@ -263,7 +238,6 @@ export class SuiData {
         }
 
         if (socket.connection_status !== ZMQ_Connection_Status.CONNECTED) {
-            console.log('bounced request')
             res.status(200).json({"ZMQ_error": "reconnecting"});
             return;
         }

--- a/simpleui-server/src/sui_data.ts
+++ b/simpleui-server/src/sui_data.ts
@@ -226,14 +226,14 @@ export class SuiData {
         // get port
         const zmq_port = SuiData.getZmqPort(req);
 
+
         // get socket
         let socket = SuiData.zmqMap.get(zmq_port);
 
         if (!socket) {
             SuiData.zmqMap.add_socket(zmq_port);
             socket = SuiData.zmqMap.get(zmq_port);
-            Logger.log(LogLevel.WARNING, `No socket for ZMQ socket with port ${zmq_port}, created new socket`);
-            Logger.log(LogLevel.DEBUG, `All ZMQ socket ports: ${Array.from(SuiData.zmqMap.socket_map.keys())}`)
+            Logger.log(LogLevel.INFO, `No socket for ZMQ socket with port ${zmq_port}, created new socket`);
         }
 
         // get and set connection timeout (is this needed anymore?)
@@ -677,8 +677,6 @@ export class SuiData {
         }
 
         if (res) {
-            const broken_links = SuiData.checkForBrokenOverlayFiles(sJson);
-            //console.log('------------- Broken links', broken_links)
             res.send(sJson);
         }
         return;

--- a/simpleui-server/src/sui_data.ts
+++ b/simpleui-server/src/sui_data.ts
@@ -236,16 +236,16 @@ export class SuiData {
             Logger.log(LogLevel.INFO, `No socket for ZMQ socket with port ${zmq_port}, created new socket`);
         }
 
-        if (socket.reconnect_attempt >= socket.max_reconnect_attempts) {
-            // close socket
-            socket.close();
-            // delete socket
-            SuiData.zmqMap.delete_socket(zmq_port);
-            // recreate socket
-            SuiData.zmqMap.add_socket(zmq_port);
-            socket = SuiData.zmqMap.get(zmq_port);
-            Logger.log(LogLevel.INFO, `Recreated socket ${zmq_port}`);
-        }
+        // if (socket.reconnect_attempt >= socket.max_reconnect_attempts) {
+        //     // close socket
+        //     socket.close();
+        //     // delete socket
+        //     SuiData.zmqMap.delete_socket(zmq_port);
+        //     // recreate socket
+        //     SuiData.zmqMap.add_socket(zmq_port);
+        //     socket = SuiData.zmqMap.get(zmq_port);
+        //     Logger.log(LogLevel.INFO, `Recreated socket ${zmq_port}`);
+        // }
 
 
         // get and set connection timeout (is this needed anymore?)

--- a/simpleui-server/src/sui_data.ts
+++ b/simpleui-server/src/sui_data.ts
@@ -236,17 +236,6 @@ export class SuiData {
             Logger.log(LogLevel.INFO, `No socket for ZMQ socket with port ${zmq_port}, created new socket`);
         }
 
-        // if (socket.reconnect_attempt >= socket.max_reconnect_attempts) {
-        //     // close socket
-        //     socket.close();
-        //     // delete socket
-        //     SuiData.zmqMap.delete_socket(zmq_port);
-        //     // recreate socket
-        //     SuiData.zmqMap.add_socket(zmq_port);
-        //     socket = SuiData.zmqMap.get(zmq_port);
-        //     Logger.log(LogLevel.INFO, `Recreated socket ${zmq_port}`);
-        // }
-
 
         // get and set connection timeout (is this needed anymore?)
         const timeout = SuiData.propOrDefault(SuiData.uiProps, 'zmqTimeout', 1000);

--- a/simpleui-server/src/sui_data.ts
+++ b/simpleui-server/src/sui_data.ts
@@ -226,7 +226,6 @@ export class SuiData {
         // get port
         const zmq_port = SuiData.getZmqPort(req);
 
-
         // get socket
         let socket = SuiData.zmqMap.get(zmq_port);
 
@@ -237,7 +236,7 @@ export class SuiData {
         }
 
 
-        // get and set connection timeout (is this needed anymore?)
+        // get and set connection timeout
         const timeout = SuiData.propOrDefault(SuiData.uiProps, 'zmqTimeout', 1000);
 
         socket.set_timeout(timeout);

--- a/simpleui-server/src/sui_data.ts
+++ b/simpleui-server/src/sui_data.ts
@@ -230,7 +230,7 @@ export class SuiData {
         // get socket
         let socket = SuiData.zmqMap.get(zmq_port);
 
-        if (!socket) {
+        if (!socket && zmq_port !== 0) {
             SuiData.zmqMap.add_socket(zmq_port);
             socket = SuiData.zmqMap.get(zmq_port);
             Logger.log(LogLevel.INFO, `No socket for ZMQ socket with port ${zmq_port}, created new socket`);

--- a/simpleui-server/src/sui_zmq.ts
+++ b/simpleui-server/src/sui_zmq.ts
@@ -16,7 +16,7 @@ import { SuiData } from './sui_data';
 import { Queue } from './queue';
 
 
-enum ZMQ_Connection_Status {
+export enum ZMQ_Connection_Status {
     CONNECTED = "connected",
     RETRY_CONNECTING = "reconnecting",                  // ZMQ_RCVTIMEO ended, attempt to reconnect
     DELAY_CONNECTING = "Waiting for a response",        // waiting for response for ZMQ_RCVTIMEO amount of time

--- a/simpleui-server/src/sui_zmq.ts
+++ b/simpleui-server/src/sui_zmq.ts
@@ -85,7 +85,7 @@ export class ZMQ_Socket_Wrapper {
 
 
             this.watchdog = setInterval( () => {
-                if ( (this.messages_sent - this.messages_received) >  4 && this.connection_status === ZMQ_Connection_Status.CONNECTED) {
+                if ( (this.messages_sent - this.messages_received) >  3 && this.connection_status === ZMQ_Connection_Status.CONNECTED) {
                     this.recreate_socket();
                 }
             }, this.watchdog_interval);
@@ -216,6 +216,7 @@ export class ZMQ_Socket_Wrapper {
             // clear http queue
             while (!this.http_queue.isEmpty()) {
                 let [_res, _req] = this.http_queue.dequeue();
+                console.log('======== clearing http queue', _res.headersSent, _res.writableEnded)
                 _res.status(269).json({"error": "shit broke"})
             }
 

--- a/simpleui-server/src/sui_zmq.ts
+++ b/simpleui-server/src/sui_zmq.ts
@@ -17,9 +17,9 @@ import { Queue } from './queue';
 
 
 enum ZMQ_Connection_Status {
-    CONNECTED,
-    CONNECTING,
-    DISCONNECTED
+    CONNECTED = "connected",
+    CONNECTING = "attempting to connect",
+    DISCONNECTED = "disconnected"
 }
 
 
@@ -212,5 +212,20 @@ export class zmq_wrapper {
             // close event listeners (message, error, item_added)?
             // zmq_wrapper_instance.http_queue.removeEventListener('item_added', () => {})
         });
+    }
+
+
+    log_status(): void {
+        if (this.socket_map.size == 0) return;
+        let msg = "--- ZMQ Socket Connection Status ---\n";
+        this.socket_map.forEach( (socket_instance: ZMQ_Socket_Wrapper, port: number) => {
+             const id = `${socket_instance.hostname}:${port}`;
+             const status = socket_instance.connection_status;
+             const line = `\t${id}\t ==> ${status}\n`;
+             msg += line;
+        });
+        msg += "------------------------------------";
+
+        Logger.log(LogLevel.DEBUG, msg);
     }
 }

--- a/simpleui-server/src/sui_zmq.ts
+++ b/simpleui-server/src/sui_zmq.ts
@@ -246,10 +246,10 @@ export class zmq_wrapper {
              const id = `${socket_instance.hostname}:${port}`;
              const status = socket_instance.connection_status;
              const queue_capacity = socket_instance.http_queue.length;
-             const queue_limit = socket_instance.http_queue.max_queue_length;
+             const queue_limit = socket_instance.http_queue.MAX_QUEUE_SIZE;
              const reconnect_attempt = socket_instance.reconnect_attempt;
              const reconnect_limit = socket_instance.max_reconnect_attempts;
-             const line = `\t${id}\t ==> ${status}\n \tHttp queue capacity: ${queue_capacity}/${queue_limit} \tReconnect attempts: ${reconnect_attempt}/${reconnect_limit}`;
+             const line = `\t${id}\t ==> ${status} \tHttp queue capacity: ${queue_capacity}/${queue_limit} \tReconnect attempts: ${reconnect_attempt}/${reconnect_limit}\n`;
              msg += line;
         });
         msg += "------------------------------------\n";

--- a/simpleui-server/src/sui_zmq.ts
+++ b/simpleui-server/src/sui_zmq.ts
@@ -84,11 +84,11 @@ export class ZMQ_Socket_Wrapper {
             this.add_messaging_listeners();
 
 
-            // this.watchdog = setInterval( () => {
-            //     if ( (this.messages_sent - this.messages_received) >  4) {
-            //         this.recreate_socket();
-            //     }
-            // }, this.watchdog_interval);
+            this.watchdog = setInterval( () => {
+                if ( (this.messages_sent - this.messages_received) >  4 && this.connection_status === ZMQ_Connection_Status.CONNECTED) {
+                    this.recreate_socket();
+                }
+            }, this.watchdog_interval);
 
             this.http_queue.events.on('item_added', () => {
                 // read the most recent item

--- a/simpleui-server/src/sui_zmq.ts
+++ b/simpleui-server/src/sui_zmq.ts
@@ -75,8 +75,8 @@ export class ZMQ_Socket_Wrapper {
                 this.connection_status = ZMQ_Connection_Status.CONNECTING;
                 this.reconnect_attempt++;
                 if (this.reconnect_attempt >= this.max_reconnect_attempts) {
-                    Logger.log(LogLevel.INFO, `Socket ${this.port} is reinitializing ${this.reconnect_attempt} >= ${this.max_reconnect_attempts} ${this.reconnect_attempt >= this.max_reconnect_attempts}`);
                     this.reconnect_attempt = 0;
+                    Logger.log(LogLevel.INFO, `Socket ${this.port} is reinitializing ${this.reconnect_attempt} >= ${this.max_reconnect_attempts} ${this.reconnect_attempt >= this.max_reconnect_attempts}`);
                     this.initalize();
                 }
             });

--- a/simpleui-server/src/sui_zmq.ts
+++ b/simpleui-server/src/sui_zmq.ts
@@ -109,7 +109,8 @@ export class ZMQ_Socket_Wrapper {
                 this.connection_status = ZMQ_Connection_Status.CONNECTING;
                 this.reconnect_attempt++;
                 if (this.reconnect_attempt > this.max_reconnect_attempts) {
-                    this.recreate_socket();
+                    //this.recreate_socket();
+                    console.log(`not recreating ${this.hostname}:${this.port}`);
                 }
             });
 

--- a/simpleui-server/src/sui_zmq.ts
+++ b/simpleui-server/src/sui_zmq.ts
@@ -5,6 +5,14 @@
  *
  *  An http request can only request data from a single zmq socket
  *
+ *
+ *
+ * svcmachineapps (down, no start)
+ *      - ZMQ_monitor_interval_ms not applied
+ *      - only incremented when request sent'
+ * svcmachineapps (up, no start)
+ *      - ZMQ_monitor_interval_ms is applied
+ *
  ******************************************************************
  */
 
@@ -18,8 +26,11 @@ import { Queue } from './queue';
 
 enum ZMQ_Connection_Status {
     CONNECTED = "connected",
-    CONNECTING = "attempting to connect",
-    DISCONNECTED = "disconnected"
+    RETRY_CONNECTING = "retrying to connect",
+    DELAY_CONNECTING = "connecting delayed",
+    DISCONNECTED = "disconnected",
+    LISTENING = "listening",
+    ACCEPTED = "accepted connection",
 }
 
 
@@ -34,7 +45,8 @@ export class ZMQ_Socket_Wrapper {
     ZMQ_monitor_interval_ms: number; // allows for `connect` and `connect_retry` event listeners https://github.com/zeromq/zeromq.js/blob/5.x/lib/index.js#L547
     reconnect_attempt: number;
     max_reconnect_attempts: number;
-    message_queue: number;
+    outgoing_batch_length: any;
+    remote_address: string;
 
 
     constructor(hostname: string, port: number, timeout: number=500, send_timeout: number=500) {
@@ -44,18 +56,22 @@ export class ZMQ_Socket_Wrapper {
         this.port = port;
         this.http_queue = new Queue();
         this.connection_status = ZMQ_Connection_Status.DISCONNECTED;
-        this.ZMQ_monitor_interval_ms = 500;
+        this.ZMQ_monitor_interval_ms = 1_000;
         this.reconnect_attempt = 0;
-        this.max_reconnect_attempts = 1_000;
-        this.message_queue = 0;
+        this.max_reconnect_attempts = 20;
+        this.remote_address = `tcp://${this.hostname}:${this.port}`;
+
+
 
         try {
             this.socket = _zmq.socket('req');
-            this.socket.setsockopt(_zmq.ZMQ_SNDTIMEO, this.ZMQ_SEND_MSG_TIMEOUT_ms);
-            this.socket.setsockopt(_zmq.ZMQ_RCVTIMEO, 30 * 1000);
-            this.socket.setsockopt(_zmq.ZMQ_CONNECT_TIMEOUT, this.timeout);
-            this.connect(this.port);
+            //this.socket.setsockopt(_zmq.ZMQ_SNDTIMEO, this.ZMQ_SEND_MSG_TIMEOUT_ms);
+            //this.socket.setsockopt(_zmq.ZMQ_RCVTIMEO, 30 * 1000);
+            //this.socket.setsockopt(_zmq.ZMQ_CONNECT_TIMEOUT, this.timeout);
+            this.connect();
             this.socket.monitor(this.ZMQ_monitor_interval_ms, 0);
+            this.outgoing_batch_length = this.socket._outgoing.length;
+
 
             this.add_connection_listeners();
             this.add_messaging_listeners();
@@ -67,13 +83,12 @@ export class ZMQ_Socket_Wrapper {
     }
 
 
-    connect(port: number) {
+    connect() {
         try {
-            Logger.log(LogLevel.VERBOSE, `ZMQ connecting to tcp://${this.hostname}:${port}`)
-            this.socket.connect(`tcp://${this.hostname}:${port}`)
+            Logger.log(LogLevel.VERBOSE, `ZMQ connecting to ${this.remote_address}`);
+            this.socket.connect(this.remote_address);
         } catch (e) {
-            Logger.log(LogLevel.ERROR, `Could not connect to tcp://${this.hostname}:${port} ${typeof port} Got error: ${e}`);
-            //process.exit(1);
+            Logger.log(LogLevel.ERROR, `Could not connect to ${this.remote_address} Got error: ${e}`);
         }
     }
 
@@ -108,17 +123,25 @@ export class ZMQ_Socket_Wrapper {
             });
 
             this.socket.on('connect_retry', (data: any) => {
-                this.connection_status = ZMQ_Connection_Status.CONNECTING;
-                this.reconnect_attempt++;
-                if (this.reconnect_attempt > this.max_reconnect_attempts) {
-                    //this.recreate_socket();
-                    this.reconnect_attempt = 0;
-                    console.log(`not recreating ${this.hostname}:${this.port}`);
-                }
+                this.connection_status = ZMQ_Connection_Status.RETRY_CONNECTING;
+                this.reconnect_attempt = this.reconnect_attempt + 1;
+            });
+            this.socket.on('connect_delay', (data: any) => {
+                this.connection_status = ZMQ_Connection_Status.DELAY_CONNECTING;
+
             });
 
             this.socket.on('disconnect', (data: any) => {
                 this.connection_status = ZMQ_Connection_Status.DISCONNECTED;
+                this.reconnect_attempt = 0;
+            });
+
+            this.socket.on('listen', (data: any) => {
+                this.connection_status = ZMQ_Connection_Status.LISTENING;
+            });
+
+            this.socket.on('accept', (data: any) => {
+                this.connection_status = ZMQ_Connection_Status.ACCEPTED;
                 this.reconnect_attempt = 0;
             });
 
@@ -131,7 +154,6 @@ export class ZMQ_Socket_Wrapper {
     add_messaging_listeners() {
         try {
             this.socket.on('message', (msg) => {
-                this.message_queue--;
                 const raw_zmq_data = msg.toString();
                 const zmq_data = SuiData.addXmlStatus(raw_zmq_data);
                 Logger.log(LogLevel.DEBUG, `Recieved ZMQ message at port ${this.port}: ${zmq_data.substring(0, 16)}`);
@@ -177,7 +199,6 @@ export class ZMQ_Socket_Wrapper {
                         `zmq request details:\n\ttimeout:\t${this.timeout}\n\tPort:\t\t${this.port}\n\tCMD:\t\t${JSON.stringify(cmd)}\n\tMsg:\t\t${zmq_request_packet}`);
                 }
                 // send request
-                this.message_queue++;
                 this.socket.send(zmq_request_packet);
             });
         } catch (err) {
@@ -188,12 +209,24 @@ export class ZMQ_Socket_Wrapper {
     recreate_socket() {
         Logger.log(LogLevel.INFO, `Recreating ${this.hostname}:${this.port}`);
         try {
-            this.close();
+            // this.close();
+            // this.socket.removeEventListener('message', () => { console.log('++++++++++++++++++++++++++++++++') });
+            // this.socket.removeEventListener('error', () => {});
+            // this.socket.removeEventListener('connect', () => {});
+            // this.socket.removeEventListener('connect_retry', () => {});
+            // this.socket.removeEventListener('connect_delay', () => {});
+            // this.socket.removeEventListener('disconnect', () => {});
+            this.http_queue.events.removeListener('item_added', () => {});
+
+            this.socket.disconnect()
+
+            this.socket = null;
+
             this.socket = _zmq.socket('req');
-            this.socket.setsockopt(_zmq.ZMQ_SNDTIMEO, this.ZMQ_SEND_MSG_TIMEOUT_ms);
-            this.socket.setsockopt(_zmq.ZMQ_RCVTIMEO, 30 * 1000);
-            this.socket.connect_timeout = this.timeout;
-            this.connect(this.port);
+            //this.socket.setsockopt(_zmq.ZMQ_SNDTIMEO, this.ZMQ_SEND_MSG_TIMEOUT_ms);
+            //this.socket.setsockopt(_zmq.ZMQ_RCVTIMEO, 30 * 1000);
+            //this.socket.connect_timeout = this.timeout;
+            this.connect();
             this.socket.monitor(this.ZMQ_monitor_interval_ms, 0);
 
             this.connection_status = ZMQ_Connection_Status.DISCONNECTED;
@@ -204,6 +237,10 @@ export class ZMQ_Socket_Wrapper {
         } catch (err) {
             Logger.log(LogLevel.ERROR, `Could not recreate ${this.hostname}:${this.port}, got error ${err}`);
         }
+    }
+
+    clear_message_queue() {
+
     }
 }
 
@@ -297,7 +334,7 @@ export class zmq_wrapper {
              const queue_limit = socket_instance.http_queue.MAX_QUEUE_SIZE;
              const reconnect_attempt = socket_instance.reconnect_attempt;
              const reconnect_limit = socket_instance.max_reconnect_attempts;
-             const line = `\t${id}\t ==> ${status} \tHttp queue capacity: ${queue_capacity}/${queue_limit} \tReconnect attempts: ${reconnect_attempt}/${reconnect_limit} \tMessage Queue: ${socket_instance.message_queue}\n`;
+             const line = `\t${id}\t ==> ${status} \tHttp queue capacity: ${queue_capacity}/${queue_limit} \tReconnect attempts: ${reconnect_attempt}/${reconnect_limit} \tBatch Size: ${socket_instance.socket?._outgoing?.length}\n`;
              msg += line;
         });
         msg += "------------------------------------\n";

--- a/simpleui-server/src/sui_zmq.ts
+++ b/simpleui-server/src/sui_zmq.ts
@@ -213,6 +213,12 @@ export class ZMQ_Socket_Wrapper {
         Logger.log(LogLevel.INFO, `Recreating ${this.hostname}:${this.port}`);
         try {
 
+            // clear http queue
+            while (!this.http_queue.isEmpty()) {
+                let [_res, _req] = this.http_queue.dequeue();
+                _res.status(269).json({"error": "shit broke"})
+            }
+
             this.socket.close();
 
             this.socket = null;

--- a/simpleui-server/src/sui_zmq.ts
+++ b/simpleui-server/src/sui_zmq.ts
@@ -119,6 +119,7 @@ export class ZMQ_Socket_Wrapper {
                     );
                 }
                 // send request
+                console.log('Got HTTP GET Request!')
                 this.messages_sent = this.messages_sent + 1;
                 this.socket.send(zmq_request_packet);
             });
@@ -154,13 +155,7 @@ export class ZMQ_Socket_Wrapper {
         }
     }
 
-    disconnect() {
-        try {
-            this.socket.disconnect(this.remote_address);
-        } catch (err) {
-            Logger.log(LogLevel.ERROR, `Could not disconnect ${this.remote_address}, got error: ${err}`);
-        }
-    }
+
 
     add_connection_listeners() {
         try {
@@ -192,6 +187,10 @@ export class ZMQ_Socket_Wrapper {
                 Logger.log(LogLevel.DEBUG, `Recieved ZMQ message at port ${this.port}: ${zmq_data.substring(0, 16)}`);
                 // get response + request from queue
                 let [res, req] = this.http_queue.dequeue();
+                if (typeof res === "string") {
+                    console.log('No more items in the HTTP queue to send to the client, returning...');
+                    return
+                }
                 // send response
                 SuiData.sendResponse(req, res, zmq_data);
             });
@@ -213,7 +212,6 @@ export class ZMQ_Socket_Wrapper {
     recreate_socket() {
         Logger.log(LogLevel.INFO, `Recreating ${this.hostname}:${this.port}`);
         try {
-            //this.http_queue.events.removeAllListeners('item_added');
 
             this.socket.close();
 

--- a/simpleui-server/src/sui_zmq.ts
+++ b/simpleui-server/src/sui_zmq.ts
@@ -59,7 +59,7 @@ export class ZMQ_Socket_Wrapper {
 
         this.connection_timeout = connect_timeout;
         this.send_timeout = send_timeout;
-        this.receive_timeout = 30_000;
+        this.receive_timeout = 500;
 
         this.monitor_interval = 1_000;
         this.watchdog_interval = 1_000;

--- a/simpleui-server/src/sui_zmq.ts
+++ b/simpleui-server/src/sui_zmq.ts
@@ -59,7 +59,6 @@ export class ZMQ_Socket_Wrapper {
         Logger.log(LogLevel.INFO, `Socket ${this.port} is initializing`);
         try {
             this.close();
-            this.reconnect_attempt = 0;
 
             this.socket = _zmq.socket('req').setsockopt(_zmq.ZMQ_SNDTIMEO, this.ZMQ_SEND_MSG_TIMEOUT_ms);
             this.socket.connect_timeout = this.timeout;
@@ -75,7 +74,11 @@ export class ZMQ_Socket_Wrapper {
             this.socket.on('connect_retry', (data: any) => {
                 this.connection_status = ZMQ_Connection_Status.CONNECTING;
                 this.reconnect_attempt++;
-                if (this.reconnect_attempt >= this.max_reconnect_attempts) { Logger.log(LogLevel.INFO, `Socket ${this.port} is reinitializing`); this.initalize(); }
+                if (this.reconnect_attempt >= this.max_reconnect_attempts) {
+                    Logger.log(LogLevel.INFO, `Socket ${this.port} is reinitializing ${this.reconnect_attempt} >= ${this.max_reconnect_attempts} ${this.reconnect_attempt >= this.max_reconnect_attempts}`);
+                    this.reconnect_attempt = 0;
+                    this.initalize();
+                }
             });
 
             this.socket.on('disconnect', (data: any) => {

--- a/simpleui-server/src/sui_zmq.ts
+++ b/simpleui-server/src/sui_zmq.ts
@@ -65,7 +65,7 @@ export class ZMQ_Socket_Wrapper {
             this.socket.on('disconnect', (data: any) => {
                 this.connection_status = ZMQ_Connection_Status.DISCONNECTED;
                 Logger.log(LogLevel.VERBOSE, `ZMQ Socket ${this.hostname}:${this.port} disconnected.`);
-            })
+            });
 
 
             this.socket.on('message', (msg) => {

--- a/simpleui-server/src/sui_zmq.ts
+++ b/simpleui-server/src/sui_zmq.ts
@@ -64,6 +64,8 @@ export class ZMQ_Socket_Wrapper {
             this.socket.connect_timeout = this.timeout;
             this.connect(this.port);
             this.socket.monitor(this.ZMQ_monitor_interval_ms, 0);
+            this.reconnect_attempt = 0;
+
 
 
             this.socket.on('connect', (data: any) => {
@@ -75,7 +77,6 @@ export class ZMQ_Socket_Wrapper {
                 this.connection_status = ZMQ_Connection_Status.CONNECTING;
                 this.reconnect_attempt++;
                 if (this.reconnect_attempt >= this.max_reconnect_attempts) {
-                    this.reconnect_attempt = 0;
                     Logger.log(LogLevel.INFO, `Socket ${this.port} is reinitializing ${this.reconnect_attempt} >= ${this.max_reconnect_attempts} ${this.reconnect_attempt >= this.max_reconnect_attempts}`);
                     this.initalize();
                 }

--- a/simpleui-server/src/sui_zmq.ts
+++ b/simpleui-server/src/sui_zmq.ts
@@ -112,6 +112,7 @@ export class ZMQ_Socket_Wrapper {
                 this.reconnect_attempt++;
                 if (this.reconnect_attempt > this.max_reconnect_attempts) {
                     //this.recreate_socket();
+                    this.reconnect_attempt = 0;
                     console.log(`not recreating ${this.hostname}:${this.port}`);
                 }
             });

--- a/simpleui-server/src/sui_zmq.ts
+++ b/simpleui-server/src/sui_zmq.ts
@@ -41,7 +41,7 @@ export class ZMQ_Socket_Wrapper {
         this.port = port;
         this.http_queue = new Queue();
         this.connection_status = ZMQ_Connection_Status.DISCONNECTED;
-        this.ZMQ_monitor_interval_ms = 5_000;
+        this.ZMQ_monitor_interval_ms = 500;
 
 
 
@@ -68,7 +68,7 @@ export class ZMQ_Socket_Wrapper {
             this.socket.on('message', (msg) => {
                 const raw_zmq_data = msg.toString();
                 const zmq_data = SuiData.addXmlStatus(raw_zmq_data);
-                Logger.log(LogLevel.DEBUG, `Recieved ZMQ message at port ${this.port}: ${zmq_data.substring(0, 105)}`);
+                Logger.log(LogLevel.DEBUG, `Recieved ZMQ message at port ${this.port}: ${zmq_data.substring(0, 16)}`);
                 // get response + request from queue
                 let [res, req] = this.http_queue.dequeue();
                 // send response
@@ -109,7 +109,7 @@ export class ZMQ_Socket_Wrapper {
                     zmq_request_packet = `<request COMMAND="${cmd.cmd}" valueName="${cmd.valueName}"/>`;
                     // log zmq details
                     Logger.log( SuiData.requestNum <= 5 ? LogLevel.INFO : LogLevel.DEBUG,
-                        `zmq details:\n\ttimeout:\t${timeout}\n\tPort:\t\t${this.port}\n\tCMD:\t\t${JSON.stringify(cmd)}\n\tMsg:\t\t${zmq_request_packet}`);
+                        `zmq request details:\n\ttimeout:\t${timeout}\n\tPort:\t\t${this.port}\n\tCMD:\t\t${JSON.stringify(cmd)}\n\tMsg:\t\t${zmq_request_packet}`);
                 }
 
                 // send request

--- a/simpleui-server/src/sui_zmq.ts
+++ b/simpleui-server/src/sui_zmq.ts
@@ -43,13 +43,14 @@ export class ZMQ_Socket_Wrapper {
         this.port = port;
         this.http_queue = new Queue();
         this.connection_status = ZMQ_Connection_Status.DISCONNECTED;
-        this.ZMQ_monitor_interval_ms = 1_000;
+        this.ZMQ_monitor_interval_ms = 500;
         this.reconnect_attempt = 0;
         this.max_reconnect_attempts = 1_000;
 
         try {
             this.socket = _zmq.socket('req')
             this.socket.setsockopt(_zmq.ZMQ_SNDTIMEO, this.ZMQ_SEND_MSG_TIMEOUT_ms);
+            this.socket.setsockopt(_zmq.ZMQ_RCVTIMEO, 30 * 1000);
             this.socket.connect_timeout = this.timeout;
             this.connect(this.port);
             this.socket.monitor(this.ZMQ_monitor_interval_ms, 0);
@@ -184,6 +185,7 @@ export class ZMQ_Socket_Wrapper {
             this.close();
             this.socket = _zmq.socket('req');
             this.socket.setsockopt(_zmq.ZMQ_SNDTIMEO, this.ZMQ_SEND_MSG_TIMEOUT_ms);
+            this.socket.setsockopt(_zmq.ZMQ_RCVTIMEO, 30 * 1000);
             this.socket.connect_timeout = this.timeout;
             this.connect(this.port);
             this.socket.monitor(this.ZMQ_monitor_interval_ms, 0);


### PR DESCRIPTION
************ Don't merge this PR yet please ************ 


The goal of this pull request is to improve the debugging ability for ZMQ related problems. Each `ZMQ_Socket_Wrapper` class now has a `connection_status` class variable which reflects the status of the socket (CONNECTED , CONNECTING, DISCONNECTED). 

Everytime simpleui server gets a data or cmd request, it will run the `zmq_wrapper` method `log_status()` which logs the status of all the ZMQ sockets in this format (if the log level is `DEBUG`)

```
--- ZMQ Socket Connection Status ---
    hostname:port     ==> connected / attempting to connect / disconnected
    hostname:port     ==> connected / attempting to connect / disconnected
    hostname:port     ==> connected / attempting to connect / disconnected
---------------------------------------
```

This pull request also changes how the ZMQ sockets are created. Previously, the sockets were created by parsing `ui.properties` when the server is first started. This is bad because we have to assume that the ZMQ info is within `ui.properties`.

This pull request moves this process to the props request handler. This allows us to get the correct name of the properties file by extracting it from the request. The same way the props handler does it. 