### PR TITLE
Add smart table

### DIFF
--- a/base_app/src/app/app.component.ts
+++ b/base_app/src/app/app.component.ts
@@ -347,9 +347,8 @@ export class AppComponent implements OnInit, AfterViewInit /*, OnChanges */ {
                 AppComponent._mouseDownSuspendsUpdates = window.confirm('Suspend data/GUI updates on MOUSEDOWN?');
             } else if (event.shiftKey && event.altKey) {
                 // SHIFT-ALT-CLICK
-                // ClientLogger.initialize();
-                // window['setLoggingFeatures']();
                 AppComponent._show_click_debug = !AppComponent._show_click_debug;
+                console.debug(`Click display is ${AppComponent._show_click_debug}`);
             } else if (event.shiftKey && !selectedTab._autoRefreshEnabled) {
                 // SHIFT-CLICK with updates paused
                 selectedTab._commands_enabled  = window.confirm(`Allow commands even when refresh is paused (developers only)?`);

--- a/base_app/src/app/app.component.ts
+++ b/base_app/src/app/app.component.ts
@@ -27,6 +27,8 @@ export class AppComponent implements OnInit, AfterViewInit /*, OnChanges */ {
     static _mouseDownSuspendsUpdates = false;
     static _minutesBeforeAutoPageReload_Default = 90; // Time until the page auto-refreshes, doing automatic garbage collection
     static _logLevel = LogLevel.CRITICAL;
+    static _show_click_debug = false;
+
 
     @Output() selectedTabChange = new EventEmitter<MatTabChangeEvent>();
 
@@ -64,6 +66,7 @@ export class AppComponent implements OnInit, AfterViewInit /*, OnChanges */ {
     @ViewChild('_tabGroup', {static: false}) _tabGroup !: MatTabGroup;
 
     static onWindowClick(event: MouseEvent) {
+        if (!this._show_click_debug) return
         const e = document.getElementById('eventMsg');
         e.innerHTML = 'Clicked on target: ';
 
@@ -344,8 +347,9 @@ export class AppComponent implements OnInit, AfterViewInit /*, OnChanges */ {
                 AppComponent._mouseDownSuspendsUpdates = window.confirm('Suspend data/GUI updates on MOUSEDOWN?');
             } else if (event.shiftKey && event.altKey) {
                 // SHIFT-ALT-CLICK
-                ClientLogger.initialize();
-                window['setLoggingFeatures']();
+                // ClientLogger.initialize();
+                // window['setLoggingFeatures']();
+                AppComponent._show_click_debug = !AppComponent._show_click_debug;
             } else if (event.shiftKey && !selectedTab._autoRefreshEnabled) {
                 // SHIFT-CLICK with updates paused
                 selectedTab._commands_enabled  = window.confirm(`Allow commands even when refresh is paused (developers only)?`);

--- a/base_app/src/app/app.module.ts
+++ b/base_app/src/app/app.module.ts
@@ -31,6 +31,7 @@ import { CommandButtonChangeService } from './services/command-button-change.ser
 import { AppEditUiPanelComponent } from './app-tab-overlay/app-edit-ui-panel-component';
 import { SmartTableComponent } from './smart-table/smart-table.component';
 import { FilterPipe } from './filter.pipe';
+import {MatSortModule} from '@angular/material/sort';
 
 @NgModule({
     declarations: [
@@ -66,7 +67,8 @@ import { FilterPipe } from './filter.pipe';
       MatTabsModule,
       NoopAnimationsModule,
       PortalModule,
-      ReactiveFormsModule
+      ReactiveFormsModule,
+      MatSortModule
   ],
   providers: [
       CommandButtonChangeService,

--- a/base_app/src/app/app.module.ts
+++ b/base_app/src/app/app.module.ts
@@ -30,6 +30,7 @@ import { SeparatorBarComponent } from './dataset-tables/separator-bar';
 import { CommandButtonChangeService } from './services/command-button-change.service';
 import { AppEditUiPanelComponent } from './app-tab-overlay/app-edit-ui-panel-component';
 import { SmartTableComponent } from './smart-table/smart-table.component';
+import { FilterPipe } from './filter.pipe';
 
 @NgModule({
     declarations: [
@@ -48,7 +49,8 @@ import { SmartTableComponent } from './smart-table/smart-table.component';
       PropDefinedTableComponent,
       SectionComponent,
       SeparatorBarComponent,
-      SmartTableComponent
+      SmartTableComponent,
+      FilterPipe
   ],
   imports: [
       BrowserModule,

--- a/base_app/src/app/app.module.ts
+++ b/base_app/src/app/app.module.ts
@@ -31,7 +31,7 @@ import { CommandButtonChangeService } from './services/command-button-change.ser
 import { AppEditUiPanelComponent } from './app-tab-overlay/app-edit-ui-panel-component';
 import { SmartTableComponent } from './smart-table/smart-table.component';
 import { FilterPipe } from './filter.pipe';
-import {MatSortModule} from '@angular/material/sort';
+import { MatSortModule } from '@angular/material/sort';
 
 @NgModule({
     declarations: [

--- a/base_app/src/app/app.module.ts
+++ b/base_app/src/app/app.module.ts
@@ -29,6 +29,7 @@ import { SectionComponent } from './section/section.component';
 import { SeparatorBarComponent } from './dataset-tables/separator-bar';
 import { CommandButtonChangeService } from './services/command-button-change.service';
 import { AppEditUiPanelComponent } from './app-tab-overlay/app-edit-ui-panel-component';
+import { SmartTableComponent } from './smart-table/smart-table.component';
 
 @NgModule({
     declarations: [
@@ -46,7 +47,8 @@ import { AppEditUiPanelComponent } from './app-tab-overlay/app-edit-ui-panel-com
       DatasetTableComponent,
       PropDefinedTableComponent,
       SectionComponent,
-      SeparatorBarComponent
+      SeparatorBarComponent,
+      SmartTableComponent
   ],
   imports: [
       BrowserModule,

--- a/base_app/src/app/filter.pipe.spec.ts
+++ b/base_app/src/app/filter.pipe.spec.ts
@@ -1,0 +1,8 @@
+import { FilterPipe } from './filter.pipe';
+
+describe('FilterPipe', () => {
+  it('create an instance', () => {
+    const pipe = new FilterPipe();
+    expect(pipe).toBeTruthy();
+  });
+});

--- a/base_app/src/app/filter.pipe.ts
+++ b/base_app/src/app/filter.pipe.ts
@@ -12,6 +12,10 @@ export class FilterPipe implements PipeTransform {
     if (!filterValues) {
       return items;
     }
+
+    if (filterValues.length == 0) {
+      return items
+    }
     return items.filter(item => {
       return filterValues.includes(item.value);
     });

--- a/base_app/src/app/filter.pipe.ts
+++ b/base_app/src/app/filter.pipe.ts
@@ -14,9 +14,8 @@ export class FilterPipe implements PipeTransform {
     }
 
     if (filterValues.length == 0) {
-      return items
+      return items;
     }
-    console.log(`items: `, items)
     return items['filteredData'].filter(item => {
       return filterValues.includes(item.value);
     });

--- a/base_app/src/app/filter.pipe.ts
+++ b/base_app/src/app/filter.pipe.ts
@@ -5,18 +5,15 @@ import { Pipe, PipeTransform } from '@angular/core';
   name: 'filter'
 })
 export class FilterPipe implements PipeTransform {
-  transform(items: any[], searchText: string): any[] {
+  transform(items: any[], filterValues: any[]): any[] {
     if (!items) {
       return [];
     }
-    if (!searchText) {
+    if (!filterValues) {
       return items;
     }
-    searchText = searchText.toLowerCase();
     return items.filter(item => {
-      // Define your filtering logic here
-      return item.value == searchText;
-
+      return filterValues.includes(item.value);
     });
   }
 }

--- a/base_app/src/app/filter.pipe.ts
+++ b/base_app/src/app/filter.pipe.ts
@@ -1,0 +1,22 @@
+
+import { Pipe, PipeTransform } from '@angular/core';
+
+@Pipe({
+  name: 'filter'
+})
+export class FilterPipe implements PipeTransform {
+  transform(items: any[], searchText: string): any[] {
+    if (!items) {
+      return [];
+    }
+    if (!searchText) {
+      return items;
+    }
+    searchText = searchText.toLowerCase();
+    return items.filter(item => {
+      // Define your filtering logic here
+      return item.value == searchText;
+
+    });
+  }
+}

--- a/base_app/src/app/filter.pipe.ts
+++ b/base_app/src/app/filter.pipe.ts
@@ -16,7 +16,8 @@ export class FilterPipe implements PipeTransform {
     if (filterValues.length == 0) {
       return items
     }
-    return items.filter(item => {
+    console.log(`items: `, items)
+    return items['filteredData'].filter(item => {
       return filterValues.includes(item.value);
     });
   }

--- a/base_app/src/app/section/section.component.html
+++ b/base_app/src/app/section/section.component.html
@@ -47,11 +47,17 @@
                             [_uiTab]="_uiTab"
                             [id]="dsItem.id">
             </dataset-table>
-            <prop-defined-table *ngIf="getTableType(dsItem) === 'PropDefinedTable'"
+            <prop-defined-table *ngIf="getTableType(dsItem) === '-----PropDefinedTable'"
                                 [_dataset]="dsItem"
                                 [_uiTab]="_uiTab"
                                 [_id]="dsItem.id">
             </prop-defined-table>
+
+            <app-smart-table *ngIf="getTableType(dsItem) === 'PropDefinedTable'"
+                                [_dataset]="dsItem"
+                                [_uiTab]="_uiTab"
+                                [_id]="dsItem.id">
+            </app-smart-table>
         </td>
     </tr>
 

--- a/base_app/src/app/section/section.component.html
+++ b/base_app/src/app/section/section.component.html
@@ -47,13 +47,13 @@
                             [_uiTab]="_uiTab"
                             [id]="dsItem.id">
             </dataset-table>
-            <prop-defined-table *ngIf="getTableType(dsItem) === '-----PropDefinedTable'"
+            <prop-defined-table *ngIf="getTableType(dsItem) === 'PropDefinedTable'"
                                 [_dataset]="dsItem"
                                 [_uiTab]="_uiTab"
                                 [_id]="dsItem.id">
             </prop-defined-table>
 
-            <app-smart-table *ngIf="getTableType(dsItem) === 'PropDefinedTable'"
+            <app-smart-table *ngIf="getTableType(dsItem) === 'smart'"
                                 [_dataset]="dsItem"
                                 [_uiTab]="_uiTab"
                                 [_id]="dsItem.id">

--- a/base_app/src/app/smart-table/smart-table.component.css
+++ b/base_app/src/app/smart-table/smart-table.component.css
@@ -1,0 +1,3 @@
+th {
+    padding: 0 15px 0 15px !important;
+}

--- a/base_app/src/app/smart-table/smart-table.component.css
+++ b/base_app/src/app/smart-table/smart-table.component.css
@@ -1,3 +1,7 @@
 th {
     padding: 0 15px 0 15px !important;
 }
+
+td {
+    padding: 0 15px 0 15px !important;
+}

--- a/base_app/src/app/smart-table/smart-table.component.html
+++ b/base_app/src/app/smart-table/smart-table.component.html
@@ -1,14 +1,18 @@
-<h2>Filter via fault status</h2>
 
 
-<mat-form-field appearance="fill">
+<mat-form-field appearance="fill" *ngIf="_uiTab?.name.toLowerCase() == 'fault list'">
     <mat-label>Fault Status Filter</mat-label>
     <mat-select multiple (selectionChange)="handleSelection($event.value)">
         <mat-option *ngFor="let status of allStatuses" [value]="status">{{status}}</mat-option>
     </mat-select>
 </mat-form-field>
 
-<table mat-table [dataSource]="_dataset.elements | filter:filterFaultValue" class="mat-elevation-z8" style="width: 100%;">
+
+<table
+  mat-table
+  [dataSource]="_uiTab?.name.toLowerCase() == 'fault list' ? (_dataset?.elements | filter:filterFaultValue) : _dataset?.elements"
+  class="mat-elevation-z8"
+  style="width: 100%;">
 
     <ng-container *ngFor="let column of getColumns()" [matColumnDef]="column">
         <th mat-header-cell *matHeaderCellDef> {{column}} </th>

--- a/base_app/src/app/smart-table/smart-table.component.html
+++ b/base_app/src/app/smart-table/smart-table.component.html
@@ -8,7 +8,6 @@
     </mat-select>
 </mat-form-field>
 
-
 <table mat-table [dataSource]="_dataset.elements | filter:filterFaultValue" class="mat-elevation-z8" style="width: 100%;">
 
     <ng-container *ngFor="let column of getColumns()" [matColumnDef]="column">

--- a/base_app/src/app/smart-table/smart-table.component.html
+++ b/base_app/src/app/smart-table/smart-table.component.html
@@ -1,7 +1,12 @@
-<p>smart-table works!</p>
-<p>{{getColumns()}}</p>
+<h2>Filter via fault status</h2>
+<button mat-raised-button (click)="onFilterFault($event)" value="">remove table filter</button>
+<button mat-raised-button (click)="onFilterFault($event)" value="none">NONE</button>
+<button mat-raised-button (click)="onFilterFault($event)" value="disabled">DISABLED</button>
+<button mat-raised-button (click)="onFilterFault($event)" value="warning">WARNING</button>
+<button mat-raised-button (click)="onFilterFault($event)" value="trip">TRIP</button>
 
-<table mat-table [dataSource]="_dataset.elements" class="mat-elevation-z8" style="width: 100%;">
+
+<table mat-table [dataSource]="_dataset.elements | filter:filterFaultValue" class="mat-elevation-z8" style="width: 100%;">
 
     <ng-container *ngFor="let column of getColumns()" [matColumnDef]="column">
         <th mat-header-cell *matHeaderCellDef> {{column}} </th>

--- a/base_app/src/app/smart-table/smart-table.component.html
+++ b/base_app/src/app/smart-table/smart-table.component.html
@@ -1,0 +1,75 @@
+<p>smart-table works!</p>
+<p>{{getColumns()}}</p>
+<table mat-table [dataSource]="_dataset.elements" class="mat-elevation-z8" style="width: 100%;">
+
+
+
+    <ng-container matColumnDef="idx">
+        <th mat-header-cell *matHeaderCellDef> Index </th>
+        <td mat-cell *matCellDef="let element"> {{element.idx}} </td>
+    </ng-container>
+    <ng-container matColumnDef="timestamp">
+        <th mat-header-cell *matHeaderCellDef> timestamp </th>
+        <td mat-cell *matCellDef="let element"> {{element.timestamp}} </td>
+    </ng-container>
+    <ng-container matColumnDef="primLoc">
+        <th mat-header-cell *matHeaderCellDef> primLoc </th>
+        <td mat-cell *matCellDef="let element"> {{element.primLoc}} </td>
+    </ng-container>
+    <ng-container matColumnDef="subLoc">
+        <th mat-header-cell *matHeaderCellDef> subLoc </th>
+        <td mat-cell *matCellDef="let element"> {{element.subLoc}} </td>
+    </ng-container>
+    <ng-container matColumnDef="mode_critical_only">
+        <th mat-header-cell *matHeaderCellDef> mode_critical_only </th>
+        <td mat-cell *matCellDef="let element"> {{element.mode_critical_only}} </td>
+    </ng-container>
+    <ng-container matColumnDef="mode_tolerant">
+        <th mat-header-cell *matHeaderCellDef> mode_tolerant </th>
+        <td mat-cell *matCellDef="let element"> {{element.mode_tolerant}} </td>
+    </ng-container>
+    <ng-container matColumnDef="mode_averse">
+        <th mat-header-cell *matHeaderCellDef> mode_averse </th>
+        <td mat-cell *matCellDef="let element"> {{element.mode_averse}} </td>
+    </ng-container>
+    <ng-container matColumnDef="fault_code">
+        <th mat-header-cell *matHeaderCellDef> fault_code </th>
+        <td mat-cell *matCellDef="let element"> {{element.fault_code}} </td>
+    </ng-container>
+    <ng-container matColumnDef="type">
+        <th mat-header-cell *matHeaderCellDef> type </th>
+        <td mat-cell *matCellDef="let element"> {{element.type}} </td>
+    </ng-container>
+    <ng-container matColumnDef="name">
+        <th mat-header-cell *matHeaderCellDef> name </th>
+        <td mat-cell *matCellDef="let element"> {{element.name}} </td>
+    </ng-container>
+    <ng-container matColumnDef="desc">
+        <th mat-header-cell *matHeaderCellDef> desc </th>
+        <td mat-cell *matCellDef="let element"> {{element.desc}} </td>
+    </ng-container>
+    <ng-container matColumnDef="warn_ms">
+        <th mat-header-cell *matHeaderCellDef> warn_ms </th>
+        <td mat-cell *matCellDef="let element"> {{element.warn_ms}} </td>
+    </ng-container>
+    <ng-container matColumnDef="trip_ms">
+        <th mat-header-cell *matHeaderCellDef> trip_ms </th>
+        <td mat-cell *matCellDef="let element"> {{element.trip_ms}} </td>
+    </ng-container>
+    <ng-container matColumnDef="conditions">
+        <th mat-header-cell *matHeaderCellDef> conditions </th>
+        <td mat-cell *matCellDef="let element"> {{element.conditions}} </td>
+    </ng-container>
+    <ng-container matColumnDef="currVal">
+        <th mat-header-cell *matHeaderCellDef> currVal </th>
+        <td mat-cell *matCellDef="let element"> {{element.currVal}} </td>
+    </ng-container>
+    <ng-container matColumnDef="value">
+        <th mat-header-cell *matHeaderCellDef> value </th>
+        <td mat-cell *matCellDef="let element"> {{element.value}} </td>
+    </ng-container>
+
+
+    <tr mat-header-row *matHeaderRowDef="getColumns()"></tr>
+    <tr mat-row *matRowDef="let row; columns: getColumns();"></tr>
+</table>

--- a/base_app/src/app/smart-table/smart-table.component.html
+++ b/base_app/src/app/smart-table/smart-table.component.html
@@ -1,9 +1,12 @@
 <h2>Filter via fault status</h2>
-<button mat-raised-button (click)="onFilterFault($event)" value="">remove table filter</button>
-<button mat-raised-button (click)="onFilterFault($event)" value="none">NONE</button>
-<button mat-raised-button (click)="onFilterFault($event)" value="disabled">DISABLED</button>
-<button mat-raised-button (click)="onFilterFault($event)" value="warning">WARNING</button>
-<button mat-raised-button (click)="onFilterFault($event)" value="trip">TRIP</button>
+
+
+<mat-form-field appearance="fill">
+    <mat-label>Fault Status Filter</mat-label>
+    <mat-select multiple (selectionChange)="handleSelection($event.value)">
+        <mat-option *ngFor="let status of allStatuses" [value]="status">{{status}}</mat-option>
+    </mat-select>
+</mat-form-field>
 
 
 <table mat-table [dataSource]="_dataset.elements | filter:filterFaultValue" class="mat-elevation-z8" style="width: 100%;">

--- a/base_app/src/app/smart-table/smart-table.component.html
+++ b/base_app/src/app/smart-table/smart-table.component.html
@@ -1,74 +1,12 @@
 <p>smart-table works!</p>
 <p>{{getColumns()}}</p>
+
 <table mat-table [dataSource]="_dataset.elements" class="mat-elevation-z8" style="width: 100%;">
 
-
-
-    <ng-container matColumnDef="idx">
-        <th mat-header-cell *matHeaderCellDef> Index </th>
-        <td mat-cell *matCellDef="let element"> {{element.idx}} </td>
+    <ng-container *ngFor="let column of getColumns()" [matColumnDef]="column">
+        <th mat-header-cell *matHeaderCellDef> {{column}} </th>
+        <td mat-cell *matCellDef="let element"> {{element[column]}} </td>
     </ng-container>
-    <ng-container matColumnDef="timestamp">
-        <th mat-header-cell *matHeaderCellDef> timestamp </th>
-        <td mat-cell *matCellDef="let element"> {{element.timestamp}} </td>
-    </ng-container>
-    <ng-container matColumnDef="primLoc">
-        <th mat-header-cell *matHeaderCellDef> primLoc </th>
-        <td mat-cell *matCellDef="let element"> {{element.primLoc}} </td>
-    </ng-container>
-    <ng-container matColumnDef="subLoc">
-        <th mat-header-cell *matHeaderCellDef> subLoc </th>
-        <td mat-cell *matCellDef="let element"> {{element.subLoc}} </td>
-    </ng-container>
-    <ng-container matColumnDef="mode_critical_only">
-        <th mat-header-cell *matHeaderCellDef> mode_critical_only </th>
-        <td mat-cell *matCellDef="let element"> {{element.mode_critical_only}} </td>
-    </ng-container>
-    <ng-container matColumnDef="mode_tolerant">
-        <th mat-header-cell *matHeaderCellDef> mode_tolerant </th>
-        <td mat-cell *matCellDef="let element"> {{element.mode_tolerant}} </td>
-    </ng-container>
-    <ng-container matColumnDef="mode_averse">
-        <th mat-header-cell *matHeaderCellDef> mode_averse </th>
-        <td mat-cell *matCellDef="let element"> {{element.mode_averse}} </td>
-    </ng-container>
-    <ng-container matColumnDef="fault_code">
-        <th mat-header-cell *matHeaderCellDef> fault_code </th>
-        <td mat-cell *matCellDef="let element"> {{element.fault_code}} </td>
-    </ng-container>
-    <ng-container matColumnDef="type">
-        <th mat-header-cell *matHeaderCellDef> type </th>
-        <td mat-cell *matCellDef="let element"> {{element.type}} </td>
-    </ng-container>
-    <ng-container matColumnDef="name">
-        <th mat-header-cell *matHeaderCellDef> name </th>
-        <td mat-cell *matCellDef="let element"> {{element.name}} </td>
-    </ng-container>
-    <ng-container matColumnDef="desc">
-        <th mat-header-cell *matHeaderCellDef> desc </th>
-        <td mat-cell *matCellDef="let element"> {{element.desc}} </td>
-    </ng-container>
-    <ng-container matColumnDef="warn_ms">
-        <th mat-header-cell *matHeaderCellDef> warn_ms </th>
-        <td mat-cell *matCellDef="let element"> {{element.warn_ms}} </td>
-    </ng-container>
-    <ng-container matColumnDef="trip_ms">
-        <th mat-header-cell *matHeaderCellDef> trip_ms </th>
-        <td mat-cell *matCellDef="let element"> {{element.trip_ms}} </td>
-    </ng-container>
-    <ng-container matColumnDef="conditions">
-        <th mat-header-cell *matHeaderCellDef> conditions </th>
-        <td mat-cell *matCellDef="let element"> {{element.conditions}} </td>
-    </ng-container>
-    <ng-container matColumnDef="currVal">
-        <th mat-header-cell *matHeaderCellDef> currVal </th>
-        <td mat-cell *matCellDef="let element"> {{element.currVal}} </td>
-    </ng-container>
-    <ng-container matColumnDef="value">
-        <th mat-header-cell *matHeaderCellDef> value </th>
-        <td mat-cell *matCellDef="let element"> {{element.value}} </td>
-    </ng-container>
-
 
     <tr mat-header-row *matHeaderRowDef="getColumns()"></tr>
     <tr mat-row *matRowDef="let row; columns: getColumns();"></tr>

--- a/base_app/src/app/smart-table/smart-table.component.html
+++ b/base_app/src/app/smart-table/smart-table.component.html
@@ -10,12 +10,13 @@
 
 <table
   mat-table
-  [dataSource]="_uiTab?.name.toLowerCase() == 'fault list' ? (_dataset?.elements | filter:filterFaultValue) : _dataset?.elements"
+  matSort
+  [dataSource]="_uiTab?.name.toLowerCase() == 'fault list' ? (datasource | filter:filterFaultValue) : datasource"
   class="mat-elevation-z8"
   style="width: 100%;">
 
     <ng-container *ngFor="let column of getColumns()" [matColumnDef]="column">
-        <th mat-header-cell *matHeaderCellDef> {{column}} </th>
+        <th mat-header-cell *matHeaderCellDef mat-sort-header> {{column}} </th>
         <td mat-cell *matCellDef="let element"> {{element[column]}} </td>
     </ng-container>
 

--- a/base_app/src/app/smart-table/smart-table.component.spec.ts
+++ b/base_app/src/app/smart-table/smart-table.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { SmartTableComponent } from './smart-table.component';
+
+describe('SmartTableComponent', () => {
+  let component: SmartTableComponent;
+  let fixture: ComponentFixture<SmartTableComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ SmartTableComponent ]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(SmartTableComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/base_app/src/app/smart-table/smart-table.component.spec.ts
+++ b/base_app/src/app/smart-table/smart-table.component.spec.ts
@@ -1,6 +1,13 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { SmartTableComponent } from './smart-table.component';
+import { FilterPipe } from '../filter.pipe';
+
+import { TabUI } from '../interfaces/props-data';
+import { DataSummary } from '../interfaces/data-summary';
+import { MatSortModule } from '@angular/material/sort';
+import { MatTableModule } from '@angular/material/table';
+
 
 describe('SmartTableComponent', () => {
   let component: SmartTableComponent;
@@ -8,16 +15,59 @@ describe('SmartTableComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [ SmartTableComponent ]
+      declarations: [
+        SmartTableComponent,
+        FilterPipe
+       ],
+       imports: [
+        MatSortModule,
+        MatTableModule
+       ]
     })
     .compileComponents();
+  });
 
+  beforeEach(() => {
     fixture = TestBed.createComponent(SmartTableComponent);
     component = fixture.componentInstance;
+
+    component._dataset = {
+      elements: [
+        {id: 1, name: 'Item 1', status: 'none'},
+        {id: 2, name: 'Item 2', status: 'disabled'},
+        {id: 3, name: 'Item 3', status: 'warning'},
+        {id: 4, name: 'Item 4', status: 'trip'},
+      ],
+      props: {
+        coloumns: [
+          ['col_1', 'column 1']
+        ]
+      }
+    }
+    component._uiTab = {
+      index: 0,
+      id: '',
+      name: 'Test smart table',
+      dataUrl: '',
+      commandUrl: '',
+      pageType: '',
+      hash: '',
+      _DataSummary: new DataSummary(),
+      _autoRefreshEnabled: false,
+      _commands_enabled: false,
+      _updateTime: 0,
+      _pendingRequestExpiration: 0,
+      disabled_buttons: ''
+
+    }
     fixture.detectChanges();
   });
 
+
+
+
+
   it('should create', () => {
     expect(component).toBeTruthy();
-  });
+  })
 });

--- a/base_app/src/app/smart-table/smart-table.component.spec.ts
+++ b/base_app/src/app/smart-table/smart-table.component.spec.ts
@@ -1,15 +1,105 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { DebugElement } from '@angular/core';
+import { By } from '@angular/platform-browser';
 
-import { SmartTableComponent } from './smart-table.component';
+import { SmartTableComponent, Fault_Status } from './smart-table.component';
 import { FilterPipe } from '../filter.pipe';
 
-import { TabUI } from '../interfaces/props-data';
 import { DataSummary } from '../interfaces/data-summary';
 import { MatSortModule } from '@angular/material/sort';
 import { MatTableModule } from '@angular/material/table';
 
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+
+
 
 describe('SmartTableComponent', () => {
+  let component: SmartTableComponent;
+  let fixture: ComponentFixture<SmartTableComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [
+        SmartTableComponent,
+        FilterPipe
+       ],
+       imports: [
+        MatSortModule,
+        MatTableModule,
+        BrowserAnimationsModule
+       ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(SmartTableComponent);
+    component = fixture.componentInstance;
+
+    component._dataset = {
+      elements: [
+        {idx: 1, name: 'Item 1', status: 'none'},
+        {idx: 2, name: 'Item 2', status: 'disabled'},
+        {idx: 3, name: 'Item 3', status: 'warning'},
+        {idx: 4, name: 'Item 4', status: 'trip'},
+      ],
+      props: {
+        columns: [
+          [ 'column 1', 'idx' ],
+          [ 'column 2', 'name' ],
+          [ 'column 3', 'status' ],
+
+        ]
+      }
+    }
+    component._uiTab = {
+      index: 0,
+      id: '',
+      name: 'Test tab',
+      dataUrl: '',
+      commandUrl: '',
+      pageType: '',
+      hash: '',
+      _DataSummary: new DataSummary(),
+      _autoRefreshEnabled: false,
+      _commands_enabled: false,
+      _updateTime: 0,
+      _pendingRequestExpiration: 0,
+      disabled_buttons: ''
+
+    }
+    fixture.detectChanges();
+  });
+
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+
+  it('should have the default filter be an empty string', () => {
+    expect(component.filterFaultValue).toEqual('');
+  });
+
+
+  it('should show the correct columns', () => {
+    const debugElement: DebugElement = fixture.debugElement;
+    const columnNames: DebugElement[] = debugElement.queryAll(By.css('th'));
+    expect(columnNames.length).toBe(3);
+    expect(columnNames[0].nativeElement.textContent.trim()).toBe('column 1');
+    expect(columnNames[1].nativeElement.textContent.trim()).toBe('column 2');
+    expect(columnNames[2].nativeElement.textContent.trim()).toBe('column 3');
+  });
+
+});
+
+
+
+
+
+
+
+describe('Fault list specific SmartTableComponent', () => {
   let component: SmartTableComponent;
   let fixture: ComponentFixture<SmartTableComponent>;
 
@@ -47,7 +137,7 @@ describe('SmartTableComponent', () => {
     component._uiTab = {
       index: 0,
       id: '',
-      name: 'Test smart table',
+      name: 'Fault List',
       dataUrl: '',
       commandUrl: '',
       pageType: '',
@@ -64,10 +154,10 @@ describe('SmartTableComponent', () => {
   });
 
 
-
-
-
-  it('should create', () => {
-    expect(component).toBeTruthy();
-  })
+  it('should have the default filter set to trip and warning', () => {
+    expect(component.filterFaultValue).toEqual(['trip', 'warning']);
+  });
 });
+
+
+

--- a/base_app/src/app/smart-table/smart-table.component.ts
+++ b/base_app/src/app/smart-table/smart-table.component.ts
@@ -1,7 +1,9 @@
-import { Component, OnInit, Input } from '@angular/core';
+import { Component, OnInit, Input, ViewChild, AfterViewInit } from '@angular/core';
 import { TabUI } from '../interfaces/props-data';
 
 
+import {MatSort, Sort} from '@angular/material/sort';
+import {MatTableDataSource} from '@angular/material/table';
 
 enum Fault_Status {
   EMPTY = "",
@@ -17,15 +19,18 @@ enum Fault_Status {
   templateUrl: './smart-table.component.html',
   styleUrls: ['./smart-table.component.css']
 })
-export class SmartTableComponent implements OnInit {
+export class SmartTableComponent implements OnInit, AfterViewInit {
   @Input() _dataset: any;
   @Input() _uiTab: TabUI;
   @Input() _id: string;
 
+  @ViewChild(MatSort) sort: MatSort;
+
 
   columns = [];
   filterFaultValue: Fault_Status|Fault_Status[] = Fault_Status.EMPTY;
-  allStatuses = ['none', 'disabled', 'warning', 'trip']
+  allStatuses = ['none', 'disabled', 'warning', 'trip'];
+  datasource: any;
 
   constructor() { }
 
@@ -33,6 +38,11 @@ export class SmartTableComponent implements OnInit {
     if (this._uiTab?.name.toLowerCase() == 'fault list') {
       this.filterFaultValue = [Fault_Status.TRIP, Fault_Status.WARNING]; // default filter
     }
+  }
+
+  ngAfterViewInit() {
+    this.datasource = new MatTableDataSource(this._dataset.elements);
+    this.datasource.sort = this.sort;
   }
 
   getColumns() {

--- a/base_app/src/app/smart-table/smart-table.component.ts
+++ b/base_app/src/app/smart-table/smart-table.component.ts
@@ -5,7 +5,7 @@ import { MatSort } from '@angular/material/sort';
 import { MatTableDataSource } from '@angular/material/table';
 
 
-enum Fault_Status {
+export enum Fault_Status {
   EMPTY = "",
   NONE = "none",
   DISABLED = "disabled",

--- a/base_app/src/app/smart-table/smart-table.component.ts
+++ b/base_app/src/app/smart-table/smart-table.component.ts
@@ -2,7 +2,6 @@ import { Component, OnInit, Input } from '@angular/core';
 import { TabUI } from '../interfaces/props-data';
 
 
-
 enum Fault_Status {
   EMPTY = "",
   NONE = "none",
@@ -10,6 +9,7 @@ enum Fault_Status {
   WARNING = "warning",
   TRIP = "trip"
 }
+
 
 @Component({
   selector: 'app-smart-table',
@@ -21,9 +21,12 @@ export class SmartTableComponent implements OnInit {
   @Input() _uiTab: TabUI;
   @Input() _id: string;
 
-
   columns = [];
   filterFaultValue: Fault_Status = Fault_Status.EMPTY;
+
+
+  allStatuses = ['', 'none', 'disabled', 'warning', 'trip']
+  // allStatuses = Object.values(Fault_Status); I would like to do this instead of we need to change transpile lib target to es2017+
 
   constructor() { }
 
@@ -53,4 +56,8 @@ export class SmartTableComponent implements OnInit {
     return columns
   }
 
+  handleSelection(selectedValues) {
+    console.log(selectedValues)
+    this.filterFaultValue = selectedValues;
+  }
 }

--- a/base_app/src/app/smart-table/smart-table.component.ts
+++ b/base_app/src/app/smart-table/smart-table.component.ts
@@ -25,13 +25,12 @@ export class SmartTableComponent implements OnInit {
   filterFaultValue: Fault_Status = Fault_Status.EMPTY;
 
 
-  allStatuses = ['', 'none', 'disabled', 'warning', 'trip']
+  allStatuses = ['none', 'disabled', 'warning', 'trip']
   // allStatuses = Object.values(Fault_Status); I would like to do this instead of we need to change transpile lib target to es2017+
 
   constructor() { }
 
   ngOnInit(): void {
-    console.log(this._dataset)
     this.getColumns()
   }
 
@@ -41,15 +40,12 @@ export class SmartTableComponent implements OnInit {
 
   onFilterFault(event: any) {
     this.filterFaultValue = event.target.value;
-    console.log(this.filterFaultValue)
   }
 
 
   getColumns() {
     let originalColumns = this._dataset?.props?.columns
-
     let columns = [];
-
     originalColumns.forEach(element => {
       columns.push(element[0])
     });
@@ -57,7 +53,6 @@ export class SmartTableComponent implements OnInit {
   }
 
   handleSelection(selectedValues) {
-    console.log(selectedValues)
     this.filterFaultValue = selectedValues;
   }
 }

--- a/base_app/src/app/smart-table/smart-table.component.ts
+++ b/base_app/src/app/smart-table/smart-table.component.ts
@@ -2,6 +2,7 @@ import { Component, OnInit, Input } from '@angular/core';
 import { TabUI } from '../interfaces/props-data';
 
 
+
 enum Fault_Status {
   EMPTY = "",
   NONE = "none",
@@ -21,33 +22,24 @@ export class SmartTableComponent implements OnInit {
   @Input() _uiTab: TabUI;
   @Input() _id: string;
 
+
   columns = [];
-  filterFaultValue: Fault_Status = Fault_Status.EMPTY;
-
-
+  filterFaultValue: Fault_Status|Fault_Status[] = Fault_Status.EMPTY;
   allStatuses = ['none', 'disabled', 'warning', 'trip']
-  // allStatuses = Object.values(Fault_Status); I would like to do this instead of we need to change transpile lib target to es2017+
 
   constructor() { }
 
   ngOnInit(): void {
-    this.getColumns()
+    if (this._uiTab?.name.toLowerCase() == 'fault list') {
+      this.filterFaultValue = [Fault_Status.TRIP, Fault_Status.WARNING]; // default filter
+    }
   }
-
-  onSearch(event: any) {
-    this.filterFaultValue = event.target.value;
-  }
-
-  onFilterFault(event: any) {
-    this.filterFaultValue = event.target.value;
-  }
-
 
   getColumns() {
-    let originalColumns = this._dataset?.props?.columns
+    const originalColumns = this._dataset?.props?.columns
     let columns = [];
     originalColumns.forEach(element => {
-      columns.push(element[0])
+      columns.push(element[0]);
     });
     return columns
   }

--- a/base_app/src/app/smart-table/smart-table.component.ts
+++ b/base_app/src/app/smart-table/smart-table.component.ts
@@ -1,6 +1,16 @@
 import { Component, OnInit, Input } from '@angular/core';
 import { TabUI } from '../interfaces/props-data';
 
+
+
+enum Fault_Status {
+  EMPTY = "",
+  NONE = "none",
+  DISABLED = "disabled",
+  WARNING = "warning",
+  TRIP = "trip"
+}
+
 @Component({
   selector: 'app-smart-table',
   templateUrl: './smart-table.component.html',
@@ -13,29 +23,7 @@ export class SmartTableComponent implements OnInit {
 
 
   columns = [];
-
-  dataSource = [
-    {
-      "value": "none",
-      "conditions": "value > Warn:0.75 > Trip:1.75",
-      "currVal": "+OOR",
-      "desc": "Tank Leak Sensor warning.",
-      "ev_details": "",
-      "fault_code": "Process-Mod1-1",
-      "idx": "1",
-      "mode_averse": "offline",
-      "mode_critical_only": "none",
-      "mode_no_response": "none",
-      "mode_tolerant": "none",
-      "name": "Mod1-Process-AnTank-2-Leak_Detected",
-      "primLoc": "Mod1",
-      "subLoc": "mod",
-      "timestamp": "20:36:24",
-      "trip_ms": "20000",
-      "type": "Leak-Flt",
-      "warn_ms": "10000"
-    }
-  ]
+  filterFaultValue: Fault_Status = Fault_Status.EMPTY;
 
   constructor() { }
 
@@ -44,6 +32,14 @@ export class SmartTableComponent implements OnInit {
     this.getColumns()
   }
 
+  onSearch(event: any) {
+    this.filterFaultValue = event.target.value;
+  }
+
+  onFilterFault(event: any) {
+    this.filterFaultValue = event.target.value;
+    console.log(this.filterFaultValue)
+  }
 
 
   getColumns() {
@@ -54,8 +50,7 @@ export class SmartTableComponent implements OnInit {
     originalColumns.forEach(element => {
       columns.push(element[0])
     });
-
-
     return columns
   }
+
 }

--- a/base_app/src/app/smart-table/smart-table.component.ts
+++ b/base_app/src/app/smart-table/smart-table.component.ts
@@ -1,0 +1,61 @@
+import { Component, OnInit, Input } from '@angular/core';
+import { TabUI } from '../interfaces/props-data';
+
+@Component({
+  selector: 'app-smart-table',
+  templateUrl: './smart-table.component.html',
+  styleUrls: ['./smart-table.component.css']
+})
+export class SmartTableComponent implements OnInit {
+  @Input() _dataset: any;
+  @Input() _uiTab: TabUI;
+  @Input() _id: string;
+
+
+  columns = [];
+
+  dataSource = [
+    {
+      "value": "none",
+      "conditions": "value > Warn:0.75 > Trip:1.75",
+      "currVal": "+OOR",
+      "desc": "Tank Leak Sensor warning.",
+      "ev_details": "",
+      "fault_code": "Process-Mod1-1",
+      "idx": "1",
+      "mode_averse": "offline",
+      "mode_critical_only": "none",
+      "mode_no_response": "none",
+      "mode_tolerant": "none",
+      "name": "Mod1-Process-AnTank-2-Leak_Detected",
+      "primLoc": "Mod1",
+      "subLoc": "mod",
+      "timestamp": "20:36:24",
+      "trip_ms": "20000",
+      "type": "Leak-Flt",
+      "warn_ms": "10000"
+    }
+  ]
+
+  constructor() { }
+
+  ngOnInit(): void {
+    console.log(this._dataset)
+    this.getColumns()
+  }
+
+
+
+  getColumns() {
+    let originalColumns = this._dataset?.props?.columns
+
+    let columns = [];
+
+    originalColumns.forEach(element => {
+      columns.push(element[0])
+    });
+
+
+    return columns
+  }
+}

--- a/base_app/src/app/smart-table/smart-table.component.ts
+++ b/base_app/src/app/smart-table/smart-table.component.ts
@@ -1,9 +1,9 @@
 import { Component, OnInit, Input, ViewChild, AfterViewInit } from '@angular/core';
 import { TabUI } from '../interfaces/props-data';
 
+import { MatSort } from '@angular/material/sort';
+import { MatTableDataSource } from '@angular/material/table';
 
-import {MatSort, Sort} from '@angular/material/sort';
-import {MatTableDataSource} from '@angular/material/table';
 
 enum Fault_Status {
   EMPTY = "",
@@ -30,7 +30,7 @@ export class SmartTableComponent implements OnInit, AfterViewInit {
   columns = [];
   filterFaultValue: Fault_Status|Fault_Status[] = Fault_Status.EMPTY;
   allStatuses = ['none', 'disabled', 'warning', 'trip'];
-  datasource: any;
+  datasource: any =  new MatTableDataSource();
 
   constructor() { }
 
@@ -41,12 +41,12 @@ export class SmartTableComponent implements OnInit, AfterViewInit {
   }
 
   ngAfterViewInit() {
-    this.datasource = new MatTableDataSource(this._dataset.elements);
+    this.datasource = new MatTableDataSource(this._dataset?.elements);
     this.datasource.sort = this.sort;
   }
 
   getColumns() {
-    const originalColumns = this._dataset?.props?.columns
+    const originalColumns = this._dataset?.props?.columns !== undefined ? this._dataset.props.columns : [];
     let columns = [];
     originalColumns.forEach(element => {
       columns.push(element[0]);

--- a/simpleui-server/src/json-string-normalizer.ts
+++ b/simpleui-server/src/json-string-normalizer.ts
@@ -212,7 +212,7 @@ export class JsonStringNormalizer {
                     const tableInfo: any = JsonStringNormalizer.getTableInfo(dsItem, $propsJson);
                     if (tableInfo['tableType'] === 'PairListTable') {
                         arr.push(JsonStringNormalizer.makePairListTableObject(dsItem, dataset));
-                    } else if (tableInfo['tableType'] === 'PropDefinedTable') {
+                    } else if (tableInfo['tableType'] === 'PropDefinedTable' || tableInfo['tableType'] === 'smart') {
                         arr.push(JsonStringNormalizer.makePropDefinedTableObject(dsItem, dataset, tableInfo['props']));
                     }
                 }
@@ -231,11 +231,8 @@ export class JsonStringNormalizer {
 
             // Determine if dsItem is in the "propDefinedTable" list
             for (const table of propsJson[0].table) {
-                if (typeof table === 'object'
-                    && typeof table['element'] === 'string'
-                    && (table['element'] === tableName)) {
-
-                    pair['tableType'] = 'PropDefinedTable';
+                if (typeof table === 'object' && typeof table['element'] === 'string' && (table['element'] === tableName)) {
+                    pair['tableType'] = table?.type ? 'smart' : 'PropDefinedTable';
                     pair['props'] = table;
                     break;
                 }


### PR DESCRIPTION
This pull request creates a new table component `SmartTable` to simpleui. This table allows for headers to be sorted. As well as allowing filtering for the `Fault List` tab. 

To specify a table as a `SmartTable`, add `table.x.type = smart`  to the table section of `ui.properties`

EX:
```properties
table.2.element = Fault_List
table.2.item = Fault
table.2.type = smart
table.2.columns = idx:Index, timestamp:Time, primLoc:Location, subLoc:Sub_loc, mode_critical_only:critical, mode_tolerant:tolerant, mode_averse:averse, fault_code:Code, type:Type, name:Name, desc:Description:width300, warn_ms:Warn (mS), trip_ms:Trip (mS), conditions:Conditions, currVal:Value, value:Fault Status
```