### PR TITLE
wrap array keys with quotes to fix warnings

### DIFF
--- a/web/html/ParamsApp/php/InsertParamValues.php
+++ b/web/html/ParamsApp/php/InsertParamValues.php
@@ -69,7 +69,7 @@ if ($result === false) {
 	writeError("1", "102", "Query failed", "");
 	exit();
 } else {
-    $outJSON = json_encode(array(response => 200, result => "1 record added"), JSON_PRETTY_PRINT);
+    $outJSON = json_encode(array("response" => 200, "result" => "1 record added"), JSON_PRETTY_PRINT);
 	writeError("0", "200", $outJSON, "Successfully completed operation");
 };
 

--- a/web/html/ParamsApp/php/ParamHelper.php
+++ b/web/html/ParamsApp/php/ParamHelper.php
@@ -20,11 +20,11 @@ function propOrDefault($props, $prop, $default) {
 
 function writeError($statusCode, $errorCode, $errorMsg, $errorContext) {
     $response = array(
-        status => $statusCode,
-        error => array(
-            code => $errorCode,
-            msg => $errorMsg,
-            context => $errorContext
+        "status" => $statusCode,
+        "error" => array(
+            "code" => $errorCode,
+            "msg" => $errorMsg,
+            "context" => $errorContext
         )
     );
     echo json_encode($response, JSON_PRETTY_PRINT);


### PR DESCRIPTION
The paramsApp was throwing errors about these keys not being wrapped in quotes