### PR TITLE
Add app wide readonly

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -14,7 +14,7 @@ env:
 on:
   push:
     branches:
-      - 'master'
+      - ['master', 'add-app-wide-readonly']
     tags:
       - 'v*'
   pull_request:

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -14,7 +14,7 @@ env:
 on:
   push:
     branches:
-      - ['master', 'add-app-wide-readonly']
+      - 'master'
     tags:
       - 'v*'
   pull_request:

--- a/base_app/src/app/app-tab-normal/app-tab-normal.component.html
+++ b/base_app/src/app/app-tab-normal/app-tab-normal.component.html
@@ -8,6 +8,7 @@
                                 [_section]="sect"
                                 [_sectionIndex]="sectionIndex"
                                 [_uiTab]="_uiTab"
+                                [_props]="_props"
                         ></app-section>
                     </td>
                 </tr>

--- a/base_app/src/app/app-tab-normal/app-tab-normal.component.ts
+++ b/base_app/src/app/app-tab-normal/app-tab-normal.component.ts
@@ -11,7 +11,9 @@ import { AppComponent } from '../app.component';
 
 export class AppTabNormalComponent implements AfterContentInit {
     @Input() _uiTab: TabUI;
+    @Input() _props: any;
     @Output() updateModelOfChildDataSet = new EventEmitter<{uiTab: any, sectionIdx: number, dataSetsIdx: number, newChildData: any}>();
+
     _initialized = false;
 
     constructor(

--- a/base_app/src/app/app.component.html
+++ b/base_app/src/app/app.component.html
@@ -90,7 +90,9 @@
             <app-tab-normal
                     *ngIf="((t['pageType'] !== 'overlay') && (t['pageType'] !== 'mock-tab'))"
                     (updateModelOfChildDataSet)="onUpdateModelOfChildDataSet($event)"
-                    [_uiTab]="t" >
+                    [_uiTab]="t"
+                    [_props]="_props"
+                    >
             </app-tab-normal>
           </div>
         </div>

--- a/base_app/src/app/app.component.ts
+++ b/base_app/src/app/app.component.ts
@@ -442,38 +442,14 @@ export class AppComponent implements OnInit, AfterViewInit /*, OnChanges */ {
                 }
             },
             err => {
-                console.error(`Error in getProps() ajax subscribe callback. ${err}`);
-                try {
-                    console.error('  name: ' + err.name + ', message: ' + err.message + ', url: ' + err.request.url);
-                } catch (err1) {
-                    console.error('Error trying to display error');
-                }
+                console.error("getProps() got an error", err);
             });
         this._propsSubscriptionState = SubscriptionState.AwaitingAsyncResponse;
     }
 
-    /**
-     * Only allows clicks on the
-     * tab labels
-     * @param e Click event
-     */
-    // negateClick(e: Event): void {
-    //     if (e.target['className'].includes('mat-tab-label')) return;
-    //     e.stopPropagation();
-    // }
-
-    /**
-     * adds the event listener to
-     * enforce app-wide readonly
-     */
-    // enforceReadonly(): void {
-    //     if (document.onclick != null) return;
-    //     document.addEventListener('click', this.negateClick, true);
-    // }
-
     onPropsUpdate(propsIn: any) {
         this._props = UTIL.deepCopy(propsIn);
-        //this._props = propsIn;
+
         if (typeof this._props.instance === 'object'
             && typeof this._props.instance['name'] === 'string') {
             this._theAppTitle = this._props.instance['name'];
@@ -485,10 +461,6 @@ export class AppComponent implements OnInit, AfterViewInit /*, OnChanges */ {
         this._props.GLOBAL = this;
 
         this.initTabDataUpdates();
-
-        // if (this._props['readonly'] == true) {
-        //     this.enforceReadonly()
-        // }
     }
 
     /**

--- a/base_app/src/app/app.component.ts
+++ b/base_app/src/app/app.component.ts
@@ -457,20 +457,19 @@ export class AppComponent implements OnInit, AfterViewInit /*, OnChanges */ {
      * tab labels
      * @param e Click event
      */
-    negateClick(e: Event): void {
-        if (e.target['className'].includes('mat-tab-label')) return;
-        e.stopPropagation();
-    }
+    // negateClick(e: Event): void {
+    //     if (e.target['className'].includes('mat-tab-label')) return;
+    //     e.stopPropagation();
+    // }
 
     /**
      * adds the event listener to
      * enforce app-wide readonly
      */
-    enforceReadonly(): void {
-        if (document.onclick != null) return;
-        document.addEventListener('click', this.negateClick, true);
-        this._commands_enabled = false;
-    }
+    // enforceReadonly(): void {
+    //     if (document.onclick != null) return;
+    //     document.addEventListener('click', this.negateClick, true);
+    // }
 
     onPropsUpdate(propsIn: any) {
         this._props = UTIL.deepCopy(propsIn);
@@ -487,9 +486,9 @@ export class AppComponent implements OnInit, AfterViewInit /*, OnChanges */ {
 
         this.initTabDataUpdates();
 
-        if (this._props['readonly'] == true) {
-            this.enforceReadonly()
-        }
+        // if (this._props['readonly'] == true) {
+        //     this.enforceReadonly()
+        // }
     }
 
     /**

--- a/base_app/src/app/app.component.ts
+++ b/base_app/src/app/app.component.ts
@@ -52,6 +52,7 @@ export class AppComponent implements OnInit, AfterViewInit /*, OnChanges */ {
     _commands_enabled = false;
     _propsSubscriptionState = SubscriptionState.Idle;
     _isDevMode = (document.location.port == "4200" ? true : false);
+    _read_only_app: boolean = false;
 
     /*
         // appOptions is normally hidden - can be enabled for development
@@ -452,6 +453,27 @@ export class AppComponent implements OnInit, AfterViewInit /*, OnChanges */ {
         this._propsSubscriptionState = SubscriptionState.AwaitingAsyncResponse;
     }
 
+    /**
+     * Only allows clicks on the
+     * tab labels
+     * @param e Click event
+     */
+    negateClick(e: Event): void {
+        if (e.target['className'].includes('mat-tab-label')) return;
+        e.stopPropagation();
+        console.log('captured click');
+
+    }
+
+    /**
+     * adds the event listener to
+     * enforce app-wide readonly
+     */
+    enforceReadonly(): void {
+        if (document.onclick != null) return;
+        document.addEventListener('click', this.negateClick, true);
+    }
+
     onPropsUpdate(propsIn: any) {
         this._props = UTIL.deepCopy(propsIn);
         //this._props = propsIn;
@@ -466,6 +488,10 @@ export class AppComponent implements OnInit, AfterViewInit /*, OnChanges */ {
         this._props.GLOBAL = this;
 
         this.initTabDataUpdates();
+
+        if (this._props['readonly'] == 'true') {
+            this.enforceReadonly()
+        }
     }
 
     /**

--- a/base_app/src/app/app.component.ts
+++ b/base_app/src/app/app.component.ts
@@ -52,7 +52,6 @@ export class AppComponent implements OnInit, AfterViewInit /*, OnChanges */ {
     _commands_enabled = false;
     _propsSubscriptionState = SubscriptionState.Idle;
     _isDevMode = (document.location.port == "4200" ? true : false);
-    _read_only_app: boolean = false;
 
     /*
         // appOptions is normally hidden - can be enabled for development
@@ -461,8 +460,6 @@ export class AppComponent implements OnInit, AfterViewInit /*, OnChanges */ {
     negateClick(e: Event): void {
         if (e.target['className'].includes('mat-tab-label')) return;
         e.stopPropagation();
-        console.log('captured click');
-
     }
 
     /**
@@ -472,6 +469,7 @@ export class AppComponent implements OnInit, AfterViewInit /*, OnChanges */ {
     enforceReadonly(): void {
         if (document.onclick != null) return;
         document.addEventListener('click', this.negateClick, true);
+        this._commands_enabled = false;
     }
 
     onPropsUpdate(propsIn: any) {
@@ -489,7 +487,7 @@ export class AppComponent implements OnInit, AfterViewInit /*, OnChanges */ {
 
         this.initTabDataUpdates();
 
-        if (this._props['readonly'] == 'true') {
+        if (this._props['readonly'] == true) {
             this.enforceReadonly()
         }
     }

--- a/base_app/src/app/dataset-tables/dataset-table.html
+++ b/base_app/src/app/dataset-tables/dataset-table.html
@@ -11,11 +11,14 @@
                                     <th colspan="2" class="tableTitle" align="center" [uid]="_dataset.u_id" >
                                         <div [className]="this._hidden ? 'sectionClosed':'sectionOpened'"
                                             [title]="fixNL(_dataset.desc)"
-                                            (click)="toggleTableDisplay()"
-                                        >&nbsp;</div>
-                                        <span *ngIf="!_dataset.url">{{ getTitle() }}</span
-                                        >&nbsp;<a *ngIf="_dataset.url" target="_blank"  href={{_dataset.url}}
-                                                  title={{fixNL(_dataset.tooltip)}}>{{ getTitle() }}</a>
+                                            (click)="toggleTableDisplay()">&nbsp;</div>
+
+                                        <span *ngIf="!_dataset.url">{{ getTitle() }}</span>
+                                            &nbsp;
+
+                                        <span *ngIf="_dataset.url && _props?.readonly" title={{fixNL(_dataset.tooltip)}}>{{ getTitle() }}</span>
+                                        <a *ngIf="_dataset.url && !_props?.readonly" target="_blank" href={{_dataset.url}}>{{ getTitle() }}</a>
+
                                     </th>
                                 </tr>
                                 </thead>

--- a/base_app/src/app/dataset-tables/dataset-table.html
+++ b/base_app/src/app/dataset-tables/dataset-table.html
@@ -11,11 +11,10 @@
                                     <th colspan="2" class="tableTitle" align="center" [uid]="_dataset.u_id" >
                                         <div [className]="this._hidden ? 'sectionClosed':'sectionOpened'"
                                             [title]="fixNL(_dataset.desc)"
-                                            (click)="toggleTableDisplay()">&nbsp;</div>
-
-                                        <span *ngIf="!_dataset.url">{{ getTitle() }}</span>
-                                            &nbsp;
-
+                                            (click)="toggleTableDisplay()"
+                                        >&nbsp;</div>
+                                        <span *ngIf="!_dataset.url">{{ getTitle() }}</span
+                                        >&nbsp;
                                         <span *ngIf="_dataset.url && _props?.readonly" title={{fixNL(_dataset.tooltip)}}>{{ getTitle() }}</span>
                                         <a *ngIf="_dataset.url && !_props?.readonly" target="_blank" href={{_dataset.url}}>{{ getTitle() }}</a>
 

--- a/base_app/src/app/section/section.component.html
+++ b/base_app/src/app/section/section.component.html
@@ -43,9 +43,10 @@
             [title]="fixNL(dsItem.desc)" class="L3"
         >
             <dataset-table *ngIf="getTableType(dsItem) === 'PairListTable'"
-                           [_dataset]="dsItem"
-                            [_uiTab]="_uiTab"
-                            [id]="dsItem.id">
+                [_dataset]="dsItem"
+                [_uiTab]="_uiTab"
+                [id]="dsItem.id"
+                [_props]="_props">
             </dataset-table>
             <prop-defined-table *ngIf="getTableType(dsItem) === 'PropDefinedTable'"
                                 [_dataset]="dsItem"

--- a/base_app/src/app/section/section.component.ts
+++ b/base_app/src/app/section/section.component.ts
@@ -19,6 +19,7 @@ export class SectionComponent implements OnInit, OnDestroy {
     @Input() _section: any;
     @Input() _sectionIndex: number;
     @Input() _uiTab: TabUI;
+    @Input() _props: any;
 
 
     constructor(

--- a/deploy_docker/run.sh
+++ b/deploy_docker/run.sh
@@ -12,7 +12,7 @@ if test "$#" \< "2"; then
     printf "\t dbName      ==> (optional) override DB name \n";
     printf "\t themeName   ==> (optional) override themeName \n";
     printf "\t urlResource ==> (optional) override the RESOURCE param for all appLink urls \n"
-    printf "\t readonly    ==> (optional) doesnt allow commands or acces to the device pages or the paramsApp \n"
+    printf "\t readonly    ==> (optional) doesnt allow commands or access to the device pages or the paramsApp \n"
     exit 1;
 fi
 

--- a/deploy_docker/run.sh
+++ b/deploy_docker/run.sh
@@ -12,6 +12,7 @@ if test "$#" \< "2"; then
     printf "\t dbName      ==> (optional) override DB name \n";
     printf "\t themeName   ==> (optional) override themeName \n";
     printf "\t urlResource ==> (optional) override the RESOURCE param for all appLink urls \n"
+    printf "\t readonly    ==> (optional) doesnt allow commands or acces to the device pages or the paramsApp \n"
     exit 1;
 fi
 

--- a/simpleui-server/src/interfaces.ts
+++ b/simpleui-server/src/interfaces.ts
@@ -2,6 +2,7 @@
 export interface CommandArgs {
     valid: boolean;
     help: string;
+    examples: string;
     errors: string;
     mode: string;
     appName: string;
@@ -13,6 +14,7 @@ export interface CommandArgs {
     themeName: string;
     mock: boolean;
     urlResource: string;
+    readonly: boolean;
 }
 
 export interface ProcessInfo {

--- a/simpleui-server/src/simpleui-server.ts
+++ b/simpleui-server/src/simpleui-server.ts
@@ -111,6 +111,8 @@ export class SimpleUIServer {
             props.appLink.forEach(p => {
                 if (p.url.includes('Parameters.html')) {
                     p.url = '';
+                    p.name = '';
+                    p.tooltip = '';
                 }
             });
         }

--- a/simpleui-server/src/simpleui-server.ts
+++ b/simpleui-server/src/simpleui-server.ts
@@ -94,16 +94,16 @@ export class SimpleUIServer {
             Logger.log(LogLevel.INFO, "Running app in readonly mode");
             props['readonly'] = true;
             // prepend 'Read Only ' to title of app
-            if (props['instance']['name'].substring(0,9) != 'Read Only') {
+            if (props['instance']['name'].substring(0,9) !== 'Read Only') {
                 props['instance']['name'] = `Read Only ${props['instance']['name']}`;
             }
             // prepend '(RO) ' to beginning of tab title
             for (let i = 0; i < props['tab'].length; i++) {
-                if (props['tab'][i]['name'].substring(0,4) != '(RO)') {
+                if (props['tab'][i]['name'].substring(0,4) !== '(RO)') {
                     props['tab'][i]['name'] = `(RO) ${props['tab'][i]['name']}`;
                 }
 
-                if (props['tab'][i]['disabled_buttons'] != 'true') {
+                if (props['tab'][i]['disabled_buttons'] !== 'true') {
                     props['tab'][i]['disabled_buttons'] = 'true';
                 }
             }

--- a/simpleui-server/src/simpleui-server.ts
+++ b/simpleui-server/src/simpleui-server.ts
@@ -88,14 +88,18 @@ export class SimpleUIServer {
                     const resourceEndIndex = link.url.indexOf('&', resourceIndex);
                     link.url = link.url.substring(0, resourceIndex + 9) + cmdVars.urlResource + link.url.substring(resourceEndIndex);
                 }
-            })
+            });
+        }
+        if (cmdVars.readonly) {
+            Logger.log(LogLevel.INFO, "Running app in readonly mode");
+            props['readonly'] = true;
         }
 
         return props;
     }
 
     static parseCommandLine(cmdLine: string): any {
-        const cmdVars: CommandArgs = <CommandArgs> {
+        const cmdVars: CommandArgs = {
             valid: true,
             help: '\nSyntax:\n\n', // Each arg help is appended in arg definition
             examples: '\n\nExample for running as a daemon:' +
@@ -120,7 +124,8 @@ export class SimpleUIServer {
             dbName: '',
             themeName: '',
             mock: false,
-            urlResource: ''
+            urlResource: '',
+            readonly: false
         };
 
         cmdVars.help += '\n    -m or --mode=     (optional) the mode (daemon or test) - defaults to daemon';
@@ -204,6 +209,11 @@ export class SimpleUIServer {
             cmdVars.urlResource = match[2];
         }
 
+        const readonly = cmdLine.includes('--readonly');
+        if (readonly) {
+            cmdVars.readonly = true;
+        }
+
         return cmdVars;
     }
 
@@ -234,6 +244,7 @@ export class SimpleUIServer {
             // Parse input arguments
             SimpleUIServer.setBinDir(process.argv[1]);
             const cli_args = process.argv.slice(2).join(" ");
+            console.log(cli_args)
             const cmdVars = SimpleUIServer.parseCommandLine(cli_args);
             PropsFileReader.cmdVars = cmdVars;
 

--- a/simpleui-server/src/simpleui-server.ts
+++ b/simpleui-server/src/simpleui-server.ts
@@ -93,11 +93,11 @@ export class SimpleUIServer {
         if (cmdVars.readonly) {
             Logger.log(LogLevel.INFO, "Running app in readonly mode");
             props['readonly'] = true;
-            // append 'Read Only ' to title of app
+            // prepend 'Read Only ' to title of app
             if (props['instance']['name'].substring(0,9) != 'Read Only') {
                 props['instance']['name'] = `Read Only ${props['instance']['name']}`;
             }
-            // append '(RO) ' to beginning of tab title
+            // prepend '(RO) ' to beginning of tab title
             for (let i = 0; i < props['tab'].length; i++) {
                 if (props['tab'][i]['name'].substring(0,4) != '(RO)') {
                     props['tab'][i]['name'] = `(RO) ${props['tab'][i]['name']}`;

--- a/simpleui-server/src/simpleui-server.ts
+++ b/simpleui-server/src/simpleui-server.ts
@@ -93,9 +93,11 @@ export class SimpleUIServer {
         if (cmdVars.readonly) {
             Logger.log(LogLevel.INFO, "Running app in readonly mode");
             props['readonly'] = true;
+            // append 'Read Only ' to title of app
             if (props['instance']['name'].substring(0,9) != 'Read Only') {
                 props['instance']['name'] = `Read Only ${props['instance']['name']}`;
             }
+            // append '(RO) ' to beginning of tab title
             for (let i = 0; i < props['tab'].length; i++) {
                 if (props['tab'][i]['name'].substring(0,4) != '(RO)') {
                     props['tab'][i]['name'] = `(RO) ${props['tab'][i]['name']}`;
@@ -105,6 +107,12 @@ export class SimpleUIServer {
                     props['tab'][i]['disabled_buttons'] = 'true';
                 }
             }
+            // remove params applink if present
+            props.appLink.forEach(p => {
+                if (p.url.includes('Parameters.html')) {
+                    p.url = '';
+                }
+            });
         }
 
         return props;

--- a/simpleui-server/src/simpleui-server.ts
+++ b/simpleui-server/src/simpleui-server.ts
@@ -93,7 +93,18 @@ export class SimpleUIServer {
         if (cmdVars.readonly) {
             Logger.log(LogLevel.INFO, "Running app in readonly mode");
             props['readonly'] = true;
-            props['instance']['name'] = `Read Only ${props['instance']['name']}`;
+            if (props['instance']['name'].substring(0,9) != 'Read Only') {
+                props['instance']['name'] = `Read Only ${props['instance']['name']}`;
+            }
+            for (let i = 0; i < props['tab'].length; i++) {
+                if (props['tab'][i]['name'].substring(0,4) != '(RO)') {
+                    props['tab'][i]['name'] = `(RO) ${props['tab'][i]['name']}`;
+                }
+
+                if (props['tab'][i]['disabled_buttons'] != 'true') {
+                    props['tab'][i]['disabled_buttons'] = 'true';
+                }
+            }
         }
 
         return props;
@@ -245,7 +256,7 @@ export class SimpleUIServer {
             // Parse input arguments
             SimpleUIServer.setBinDir(process.argv[1]);
             const cli_args = process.argv.slice(2).join(" ");
-            console.log(cli_args)
+
             const cmdVars = SimpleUIServer.parseCommandLine(cli_args);
             PropsFileReader.cmdVars = cmdVars;
 

--- a/simpleui-server/src/simpleui-server.ts
+++ b/simpleui-server/src/simpleui-server.ts
@@ -93,6 +93,7 @@ export class SimpleUIServer {
         if (cmdVars.readonly) {
             Logger.log(LogLevel.INFO, "Running app in readonly mode");
             props['readonly'] = true;
+            props['instance']['name'] = `Read Only ${props['instance']['name']}`;
         }
 
         return props;


### PR DESCRIPTION
This PR adds the ability to put the simpleUI instance into a read-only mode by adding the CLI argument `--readonly`. This mode removes the ParamsApp link if it's present, disabled all buttons, and removes links to the device pages