### PR TITLE
Add app wide readonly

### DIFF
--- a/base_app/src/app/app-tab-normal/app-tab-normal.component.html
+++ b/base_app/src/app/app-tab-normal/app-tab-normal.component.html
@@ -8,6 +8,7 @@
                                 [_section]="sect"
                                 [_sectionIndex]="sectionIndex"
                                 [_uiTab]="_uiTab"
+                                [_props]="_props"
                         ></app-section>
                     </td>
                 </tr>

--- a/base_app/src/app/app-tab-normal/app-tab-normal.component.ts
+++ b/base_app/src/app/app-tab-normal/app-tab-normal.component.ts
@@ -11,7 +11,9 @@ import { AppComponent } from '../app.component';
 
 export class AppTabNormalComponent implements AfterContentInit {
     @Input() _uiTab: TabUI;
+    @Input() _props: any;
     @Output() updateModelOfChildDataSet = new EventEmitter<{uiTab: any, sectionIdx: number, dataSetsIdx: number, newChildData: any}>();
+
     _initialized = false;
 
     constructor(

--- a/base_app/src/app/app.component.html
+++ b/base_app/src/app/app.component.html
@@ -90,7 +90,9 @@
             <app-tab-normal
                     *ngIf="((t['pageType'] !== 'overlay') && (t['pageType'] !== 'mock-tab'))"
                     (updateModelOfChildDataSet)="onUpdateModelOfChildDataSet($event)"
-                    [_uiTab]="t" >
+                    [_uiTab]="t"
+                    [_props]="_props"
+                    >
             </app-tab-normal>
           </div>
         </div>

--- a/base_app/src/app/app.component.ts
+++ b/base_app/src/app/app.component.ts
@@ -442,19 +442,14 @@ export class AppComponent implements OnInit, AfterViewInit /*, OnChanges */ {
                 }
             },
             err => {
-                console.error(`Error in getProps() ajax subscribe callback. ${err}`);
-                try {
-                    console.error('  name: ' + err.name + ', message: ' + err.message + ', url: ' + err.request.url);
-                } catch (err1) {
-                    console.error('Error trying to display error');
-                }
+                console.error("getProps() got an error", err);
             });
         this._propsSubscriptionState = SubscriptionState.AwaitingAsyncResponse;
     }
 
     onPropsUpdate(propsIn: any) {
         this._props = UTIL.deepCopy(propsIn);
-        //this._props = propsIn;
+
         if (typeof this._props.instance === 'object'
             && typeof this._props.instance['name'] === 'string') {
             this._theAppTitle = this._props.instance['name'];

--- a/base_app/src/app/dataset-tables/dataset-table.html
+++ b/base_app/src/app/dataset-tables/dataset-table.html
@@ -14,8 +14,10 @@
                                             (click)="toggleTableDisplay()"
                                         >&nbsp;</div>
                                         <span *ngIf="!_dataset.url">{{ getTitle() }}</span
-                                        >&nbsp;<a *ngIf="_dataset.url" target="_blank"  href={{_dataset.url}}
-                                                  title={{fixNL(_dataset.tooltip)}}>{{ getTitle() }}</a>
+                                        >&nbsp;
+                                        <span *ngIf="_dataset.url && _props?.readonly" title={{fixNL(_dataset.tooltip)}}>{{ getTitle() }}</span>
+                                        <a *ngIf="_dataset.url && !_props?.readonly" target="_blank" href={{_dataset.url}}>{{ getTitle() }}</a>
+
                                     </th>
                                 </tr>
                                 </thead>

--- a/base_app/src/app/section/section.component.html
+++ b/base_app/src/app/section/section.component.html
@@ -43,9 +43,10 @@
             [title]="fixNL(dsItem.desc)" class="L3"
         >
             <dataset-table *ngIf="getTableType(dsItem) === 'PairListTable'"
-                           [_dataset]="dsItem"
-                            [_uiTab]="_uiTab"
-                            [id]="dsItem.id">
+                [_dataset]="dsItem"
+                [_uiTab]="_uiTab"
+                [id]="dsItem.id"
+                [_props]="_props">
             </dataset-table>
             <prop-defined-table *ngIf="getTableType(dsItem) === 'PropDefinedTable'"
                                 [_dataset]="dsItem"

--- a/base_app/src/app/section/section.component.ts
+++ b/base_app/src/app/section/section.component.ts
@@ -19,6 +19,7 @@ export class SectionComponent implements OnInit, OnDestroy {
     @Input() _section: any;
     @Input() _sectionIndex: number;
     @Input() _uiTab: TabUI;
+    @Input() _props: any;
 
 
     constructor(

--- a/deploy_docker/run.sh
+++ b/deploy_docker/run.sh
@@ -12,6 +12,7 @@ if test "$#" \< "2"; then
     printf "\t dbName      ==> (optional) override DB name \n";
     printf "\t themeName   ==> (optional) override themeName \n";
     printf "\t urlResource ==> (optional) override the RESOURCE param for all appLink urls \n"
+    printf "\t readonly    ==> (optional) doesnt allow commands or access to the device pages or the paramsApp \n"
     exit 1;
 fi
 

--- a/simpleui-server/src/interfaces.ts
+++ b/simpleui-server/src/interfaces.ts
@@ -2,6 +2,7 @@
 export interface CommandArgs {
     valid: boolean;
     help: string;
+    examples: string;
     errors: string;
     mode: string;
     appName: string;
@@ -13,6 +14,7 @@ export interface CommandArgs {
     themeName: string;
     mock: boolean;
     urlResource: string;
+    readonly: boolean;
 }
 
 export interface ProcessInfo {

--- a/simpleui-server/src/simpleui-server.ts
+++ b/simpleui-server/src/simpleui-server.ts
@@ -102,10 +102,7 @@ export class SimpleUIServer {
                 if (!props['tab'][i]['name'].startsWith('(RO)')) {
                     props['tab'][i]['name'] = `(RO) ${props['tab'][i]['name']}`;
                 }
-
-                if (props['tab'][i]['disabled_buttons'] !== 'true') {
-                    props['tab'][i]['disabled_buttons'] = 'true';
-                }
+                props['tab'][i]['disabled_buttons'] = 'true';
             }
             // remove params applink if present
             props.appLink.forEach(p => {

--- a/simpleui-server/src/simpleui-server.ts
+++ b/simpleui-server/src/simpleui-server.ts
@@ -88,14 +88,40 @@ export class SimpleUIServer {
                     const resourceEndIndex = link.url.indexOf('&', resourceIndex);
                     link.url = link.url.substring(0, resourceIndex + 9) + cmdVars.urlResource + link.url.substring(resourceEndIndex);
                 }
-            })
+            });
+        }
+        if (cmdVars.readonly) {
+            Logger.log(LogLevel.INFO, "Running app in readonly mode");
+            props['readonly'] = true;
+            // prepend 'Read Only ' to title of app
+            if (props['instance']['name'].substring(0,9) !== 'Read Only') {
+                props['instance']['name'] = `Read Only ${props['instance']['name']}`;
+            }
+            // prepend '(RO) ' to beginning of tab title
+            for (let i = 0; i < props['tab'].length; i++) {
+                if (props['tab'][i]['name'].substring(0,4) !== '(RO)') {
+                    props['tab'][i]['name'] = `(RO) ${props['tab'][i]['name']}`;
+                }
+
+                if (props['tab'][i]['disabled_buttons'] !== 'true') {
+                    props['tab'][i]['disabled_buttons'] = 'true';
+                }
+            }
+            // remove params applink if present
+            props.appLink.forEach(p => {
+                if (p.url.includes('Parameters.html')) {
+                    p.url = '';
+                    p.name = '';
+                    p.tooltip = '';
+                }
+            });
         }
 
         return props;
     }
 
     static parseCommandLine(cmdLine: string): any {
-        const cmdVars: CommandArgs = <CommandArgs> {
+        const cmdVars: CommandArgs = {
             valid: true,
             help: '\nSyntax:\n\n', // Each arg help is appended in arg definition
             examples: '\n\nExample for running as a daemon:' +
@@ -120,7 +146,8 @@ export class SimpleUIServer {
             dbName: '',
             themeName: '',
             mock: false,
-            urlResource: ''
+            urlResource: '',
+            readonly: false
         };
 
         cmdVars.help += '\n    -m or --mode=     (optional) the mode (daemon or test) - defaults to daemon';
@@ -204,6 +231,11 @@ export class SimpleUIServer {
             cmdVars.urlResource = match[2];
         }
 
+        const readonly = cmdLine.includes('--readonly');
+        if (readonly) {
+            cmdVars.readonly = true;
+        }
+
         return cmdVars;
     }
 
@@ -234,6 +266,7 @@ export class SimpleUIServer {
             // Parse input arguments
             SimpleUIServer.setBinDir(process.argv[1]);
             const cli_args = process.argv.slice(2).join(" ");
+
             const cmdVars = SimpleUIServer.parseCommandLine(cli_args);
             PropsFileReader.cmdVars = cmdVars;
 

--- a/simpleui-server/src/simpleui-server.ts
+++ b/simpleui-server/src/simpleui-server.ts
@@ -94,12 +94,12 @@ export class SimpleUIServer {
             Logger.log(LogLevel.INFO, "Running app in readonly mode");
             props['readonly'] = true;
             // prepend 'Read Only ' to title of app
-            if (props['instance']['name'].substring(0,9) !== 'Read Only') {
+            if (!props['instance']['name'].startsWith('Read Only')) {
                 props['instance']['name'] = `Read Only ${props['instance']['name']}`;
             }
             // prepend '(RO) ' to beginning of tab title
             for (let i = 0; i < props['tab'].length; i++) {
-                if (props['tab'][i]['name'].substring(0,4) !== '(RO)') {
+                if (!props['tab'][i]['name'].startsWith('(RO)')) {
                     props['tab'][i]['name'] = `(RO) ${props['tab'][i]['name']}`;
                 }
 

--- a/simpleui-server/src/simpleui-server.ts
+++ b/simpleui-server/src/simpleui-server.ts
@@ -228,8 +228,7 @@ export class SimpleUIServer {
             cmdVars.urlResource = match[2];
         }
 
-        const readonly = cmdLine.includes('--readonly');
-        if (readonly) {
+        if (cmdLine.includes('--readonly')) {
             cmdVars.readonly = true;
         }
 

--- a/simpleui-server/src/sui_zmq.ts
+++ b/simpleui-server/src/sui_zmq.ts
@@ -49,7 +49,6 @@ export class ZmqSocket {
             let zmqRequestPacket = "";
 
             if (req.method === 'POST') {
-                console.log('--- got CMD')
                 zmqRequestPacket = SuiData.buildZmqCmdPacket(req);
             }
             else {
@@ -57,8 +56,6 @@ export class ZmqSocket {
             }
             // send request
             this.outboundMessages += 1;
-            if (zmqRequestPacket.includes("cmd="))
-                console.log(`Sending ZMQ: ${zmqRequestPacket}`)
             this.socket.send(zmqRequestPacket);
         });
 
@@ -148,6 +145,7 @@ export class ZmqSocket {
     send(msg: string) {
         try {
             this.socket.send(msg);
+            Logger.log(LogLevel.DEBUG, `Sending the following ZMQ packet: ${msg}`);
         } catch (err) {
             Logger.log(LogLevel.ERROR, `Socket ${this.id} could not send ${msg}, got error: ${err}`);
         }
@@ -160,10 +158,10 @@ export class ZmqSocket {
     }
 
     recreateSocket() {
-            Logger.log(LogLevel.INFO, `Recreating the socket for ${this.id}`);
-            this.close();
-            this.httpQueue.flush_queue();
-            this.initialize();
+        Logger.log(LogLevel.INFO, `Recreating the socket for ${this.id}`);
+        this.close();
+        this.httpQueue.flush_queue();
+        this.initialize();
     }
 }
 

--- a/simpleui-server/src/sui_zmq.ts
+++ b/simpleui-server/src/sui_zmq.ts
@@ -10,11 +10,11 @@
 
 
 var _zmq = require('zeromq');
-import {ServerUtil} from './server-util';
-import {Logger, LogLevel} from './server-logger';
+import { ServerUtil } from './server-util';
+import { Logger, LogLevel } from './server-logger';
 import { SuiData } from './sui_data';
 import { HttpQueue } from './queue';
-
+import { PropsFileReader } from './props-file-reader';
 
 
 export enum ZmqConnectionStatus {
@@ -54,9 +54,13 @@ export class ZmqSocket {
             else {
                 zmqRequestPacket = SuiData.buildZmqDataPacket(req);
             }
+
+            // dont send if in readonly mode and packet is a cmd (redundency)
+            if (PropsFileReader.cmdVars?.readonly && zmqRequestPacket.includes("cmd=")) { return; }
+
             // send request
             this.outboundMessages += 1;
-            this.socket.send(zmqRequestPacket);
+            this.send(zmqRequestPacket);
         });
 
         this.watchdogInterval = setInterval( () => {


### PR DESCRIPTION
This PR adds a app-wide readonly mode via a CLI flag `--readonly`. The readonly mode disables all buttons, removes the ParamsApp link, and any links on the IO tabs.

It works by appending a readonly property to the app's properties. Then, buttons and links work conditionally.

P.S. please ignore the weird commits. I was messing around with git and ended up messing up the commits of this branch